### PR TITLE
feat(BE-21): add mine service url endpoint

### DIFF
--- a/internal/model/mined_image.go
+++ b/internal/model/mined_image.go
@@ -24,3 +24,7 @@ type MineImageResponse struct {
 	DateCreated  time.Time `json:"date_created"`
 	DateModified time.Time `json:"date_modified"`
 }
+
+type MineImageUrlRequest struct {
+	Url string `bson:"url" json:"url" validate:"url,required"`
+}

--- a/pkg/handler/mine-service/mine-service.go
+++ b/pkg/handler/mine-service/mine-service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"github.com/workshopapps/pictureminer.api/internal/model"
 	mineservice "github.com/workshopapps/pictureminer.api/service/mine-service"
 	"github.com/workshopapps/pictureminer.api/utility"
 )
@@ -42,6 +43,56 @@ func (base *Controller) Post(c *gin.Context) {
 	minedImage, err := mineservice.MineServiceUpload(image, filename)
 	if err != nil {
 		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "server error", nil, err.Error())
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	rd := utility.BuildSuccessResponse(http.StatusCreated, "image successfully mined", minedImage)
+	c.JSON(http.StatusOK, rd)
+}
+
+func (base *Controller) MineImageUrl(c *gin.Context) {
+
+	req := model.MineImageUrlRequest{}
+
+	err := c.ShouldBind(&req)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "internal server error", nil, err.Error())
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	err = base.Validate.Struct(&req)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "invalid url", nil, nil)
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	response, err := http.Get(req.Url)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "could not fetch image from url", nil, err.Error())
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	var image = response.Body
+
+	defer response.Body.Close()
+
+	urlSplit := strings.Split(req.Url, "/")[1:]
+	urlSlice := urlSplit[len(urlSplit)-1:]
+	var filename string = urlSlice[0]
+
+	if !strings.HasSuffix(filename, ".png") && !strings.HasSuffix(filename, ".jpg") && !strings.HasSuffix(filename, ".jpeg") {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "invalid file", nil, gin.H{"error": "file is not an image"})
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	minedImage, err := mineservice.MineServiceUpload(image, filename)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "could not save image", nil, err.Error())
 		c.JSON(http.StatusBadRequest, rd)
 		return
 	}

--- a/pkg/repository/microservice/microservice.go
+++ b/pkg/repository/microservice/microservice.go
@@ -13,7 +13,7 @@ import (
 	"github.com/workshopapps/pictureminer.api/internal/model"
 )
 
-func GetImageContent(file multipart.File, filename string) (*model.MicroserviceResponse, error) {
+func GetImageContent(file io.ReadCloser, filename string) (*model.MicroserviceResponse, error) {
 	microserviceHost := config.GetConfig().Python.MicroserviceHost
 
 	req, err := SetupMultipartRequest(file, microserviceHost, "head.jpeg")
@@ -42,7 +42,7 @@ func GetImageContent(file multipart.File, filename string) (*model.MicroserviceR
 	return &content, nil
 }
 
-func SetupMultipartRequest(file multipart.File, microserviceHost, filename string) (*http.Request, error) {
+func SetupMultipartRequest(file io.ReadCloser, microserviceHost, filename string) (*http.Request, error) {
 	defer file.Close()
 
 	body := &bytes.Buffer{}

--- a/pkg/repository/storage/s3/s3upload.go
+++ b/pkg/repository/storage/s3/s3upload.go
@@ -1,7 +1,7 @@
 package s3
 
 import (
-	"mime/multipart"
+	"io"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -45,7 +45,7 @@ func ConnectAws() *session.Session {
 	return s3session
 }
 
-func UploadImage(file multipart.File, filename string) (string, error) {
+func UploadImage(file io.ReadCloser, filename string) (string, error) {
 	uploader := s3manager.NewUploader(s3session)
 	MyBucket = config.GetConfig().S3.BucketName
 

--- a/pkg/router/mine-service.go
+++ b/pkg/router/mine-service.go
@@ -15,6 +15,7 @@ func MineServiceUpload(r *gin.Engine, validate *validator.Validate, ApiVersion s
 	authUrl := r.Group(fmt.Sprintf("/api/%v", ApiVersion))
 	{
 		authUrl.POST("/mine-service", mineservice.Post)
+		authUrl.POST("/mine-service/url", mineservice.MineImageUrl)
 	}
 	return r
 }

--- a/service/mine-service/mine-service.go
+++ b/service/mine-service/mine-service.go
@@ -1,7 +1,7 @@
 package mineservice
 
 import (
-	"mime/multipart"
+	"io"
 	"strings"
 	"time"
 
@@ -17,13 +17,8 @@ var (
 	imageCollection = "mined_images"
 )
 
-func MineServiceUpload(image multipart.File, filename string) (*model.MineImageResponse, error) {
+func MineServiceUpload(image io.ReadCloser, filename string) (*model.MineImageResponse, error) {
 	hashedImage, err := utility.HashImage(image)
-	if err != nil {
-		return nil, err
-	}
-
-	content, err := microservice.GetImageContent(image, filename)
 	if err != nil {
 		return nil, err
 	}
@@ -32,6 +27,11 @@ func MineServiceUpload(image multipart.File, filename string) (*model.MineImageR
 	ext := str[len(str)-1]
 
 	imagePath, err := s3.UploadImage(image, hashedImage+"."+ext)
+	if err != nil {
+		return nil, err
+	}
+
+	content, err := microservice.GetImageContent(image, filename)
 	if err != nil {
 		return nil, err
 	}

--- a/utility/hash.go
+++ b/utility/hash.go
@@ -4,10 +4,9 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io"
-	"mime/multipart"
 )
 
-func HashImage(image multipart.File) (string, error) {
+func HashImage(image io.ReadCloser) (string, error) {
 
 	hash := sha256.New()
 	_, err := io.Copy(hash, image)


### PR DESCRIPTION
Linear task https://linear.app/team-scale/issue/BE-21/setup-apimine-serviceurl
- this allows a user to be able to mine an image providing just the url

- Refactored the s3 upload method to use a io.Readcloser instead of a multipart.File so functionality can be shared between the two mine service handlers.