### PR TITLE
feat(BE-51):Create endpoint to return a list of all mined-images in our API(admin)

### DIFF
--- a/pkg/handler/admin/admin.go
+++ b/pkg/handler/admin/admin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
+	"github.com/workshopapps/pictureminer.api/internal/config"
 	"github.com/workshopapps/pictureminer.api/service/admin"
 	"github.com/workshopapps/pictureminer.api/utility"
 )
@@ -30,6 +31,17 @@ func (base *Controller) GetUsers(c *gin.Context) {
 
 // this returns the mined images of all users
 func (base *Controller) GetAllMinedImages(c *gin.Context) {
+
+	secretKey := config.GetConfig().Server.Secret
+	token := utility.ExtractToken(c)
+
+	_, err := utility.GetKey("id", token, secretKey)
+
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusUnauthorized, "failed", "could not verify token", nil, gin.H{"error": err.Error()})
+		c.JSON(http.StatusUnauthorized, rd)
+		return
+	}
 
 	minedImages, err := admin.GetMinedImages()
 	if err != nil {

--- a/pkg/handler/admin/admin.go
+++ b/pkg/handler/admin/admin.go
@@ -23,7 +23,23 @@ func (base *Controller) GetUsers(c *gin.Context) {
 		return
 	}
 
-	rd := utility.BuildSuccessResponse(http.StatusOK, "success", map[string]interface{}{"data": users})
+	rd := utility.BuildSuccessResponse(http.StatusOK, "success", gin.H{"data": users})
+	c.JSON(http.StatusOK, rd)
+
+}
+
+// this returns the mined images of all users
+func (base *Controller) GetAllMinedImages(c *gin.Context) {
+
+	minedImages, err := admin.GetMinedImages()
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusInternalServerError, "error", err.Error(), err, nil)
+		c.JSON(http.StatusInternalServerError, rd)
+		return
+
+	}
+
+	rd := utility.BuildSuccessResponse(http.StatusOK, "success", gin.H{"data": minedImages})
 	c.JSON(http.StatusOK, rd)
 
 }

--- a/pkg/router/admin.go
+++ b/pkg/router/admin.go
@@ -6,7 +6,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"github.com/workshopapps/pictureminer.api/pkg/handler/admin"
-  // "github.com/workshopapps/pictureminer.api/pkg/handler/user"
+
+	// "github.com/workshopapps/pictureminer.api/pkg/handler/user"
 	"github.com/workshopapps/pictureminer.api/utility"
 )
 
@@ -16,6 +17,7 @@ func Admin(r *gin.Engine, validate *validator.Validate, ApiVersion string, logge
 	adminUrl := r.Group(fmt.Sprintf("/api/%v", ApiVersion))
 	{
 		adminUrl.GET("/admin/users", admin.GetUsers)
+		adminUrl.GET("/admin/mined-images", admin.GetAllMinedImages)
 	}
 	return r
 }

--- a/service/admin/admin.go
+++ b/service/admin/admin.go
@@ -23,3 +23,18 @@ func GetUsers() ([]model.User, error) {
 
 	return users, nil
 }
+
+func GetMinedImages() ([]model.MinedImage, error){
+
+	ctx := context.TODO()
+	cursor, err := mongodb.SelectFromCollection(ctx, config.GetConfig().Mongodb.Database, constants.ImageCollection, bson.M{})
+
+	if err != nil {
+		return []model.MinedImage{}, err
+	}
+
+	var minedImages []model.MinedImage
+	cursor.All(ctx, &minedImages)
+
+	return minedImages, nil
+}

--- a/utility/email.go
+++ b/utility/email.go
@@ -2,12 +2,11 @@ package utility
 
 import (
 	"fmt"
-	"github.com/workshopapps/pictureminer.api/utility"
 	"net/smtp"
 	"os"
 )
 
-func EmailSender(senderEmail string, password string, receiverEmail []string, subject string, body string) utility.Response {
+func EmailSender(senderEmail string, password string, receiverEmail []string, subject string, body string) Response {
 	//connect
 	host := os.Getenv("host")
 	port := os.Getenv("port")
@@ -20,8 +19,8 @@ func EmailSender(senderEmail string, password string, receiverEmail []string, su
 	//Send Email
 	err := smtp.SendMail(address, auth, senderEmail, receiverEmail, message)
 	if err != nil {
-		rd := utility.BuildErrorResponse(550, "error", "Unable to send email", err, nil)
+		rd := BuildErrorResponse(550, "error", "Unable to send email", err, nil)
 		return rd
 	}
-	return utility.BuildSuccessResponse(250, "Email sent successfully", nil)
+	return BuildSuccessResponse(250, "Email sent successfully", nil)
 }


### PR DESCRIPTION
**ENDPOINT:**

- Created an endpoint to return all mined images to an admin user.
- Returns an object containing all the mined images created by a normal user

**LINEAR TICKET:**
- https://linear.app/team-scale/issue/BE-51/create-endpoint-to-return-a-list-of-all-mined-images-in-our-apiadmin

**Test Endpoint:**
to test my endpoint, you need to be logged in to get an access token.
send a post request to this http://44.211.169.234:9000/api/v1/login using this same exact user(johndoe)
i.e.
`curl http://44.211.169.234:9000/api/v1/login --json '{"email": "johndoe@email.com", "password": "password"}'`

this would return an object containg the access token.

then send a GET request to  http://44.211.169.234:9000/api/v1/admin/mined-images
i.e. 
```
curl http://44.211.169.234:9000/api/v1/admin/mined-images \
   -H "Accept: application/json" \
   -H "Authorization: Bearer {token}"
```
**NOTE:** this `{token}` is a placeholder so you need to replace it with the access token you got when you logged in

this would return alll the mined images present in our api

**PREVIEW:**
![2022-11-25-081608_1883x434_scrot](https://user-images.githubusercontent.com/71889751/203923174-ab62a864-9970-4437-bcc3-e24c443406c4.png)


![2022-11-25-081733_1821x644_scrot](https://user-images.githubusercontent.com/71889751/203923208-8107d3db-e883-4650-afa8-84301c3ba7fa.png)

**NOTE:**
[jq](https://github.com/stedolan/jq) is a command line utility used to process json.
i just piped to it to make the output look better

