### PR TITLE
fea(BE-40): add Prompt in image endpoint

### DIFF
--- a/pkg/handler/mine-service/prompt.go
+++ b/pkg/handler/mine-service/prompt.go
@@ -10,58 +10,142 @@ import (
 	"github.com/workshopapps/pictureminer.api/utility"
 )
 
-func (base *Controller) PromptMineImageUpload(c *gin.Context) {
+const FailedStatus = `failed`
+const (
+	VerifiedTokenMessage             = `Could not verify token`
+	InvalidRequestMessage            = `Invalid request`
+	InvalidFileMessage               = `Invalid file`
+	InvalidUrlMessage                = `Invalid url`
+	SuccessfulMiningMessage          = `Mine image successful`
+	UndefinedErrorMessage            = `Undefined error`
+	UnableToFetchImageFromUrlMessage = "Could not fetch image from url"
+	UnableToParseFileMessage         = "Could not parse file"
+	UnableToBindUrlMessage           = "Unable to bind url parameter"
+)
 
-	secretKey := config.GetConfig().Server.Secret
-	token := utility.ExtractToken(c)
-	_, err := utility.GetKey("id", token, secretKey)
+const (
+	PromptNotSpecifiedError = "Prompt Param not specified"
+	FileIsNotAnImageError   = "File is not an image"
+	FileIsNotPresentError   = "File is not present"
+)
+
+func (base *Controller) PromptMineImageUpload(c *gin.Context) {
+	err := isTokenVerified(c)
 	if err != nil {
-		rd := utility.BuildErrorResponse(http.StatusUnauthorized, "failed", "could not verify token", nil, gin.H{"error": err.Error()})
+		rd := utility.BuildErrorResponse(http.StatusUnauthorized, FailedStatus, VerifiedTokenMessage, nil, makeErrorMap(err.Error()))
 		c.JSON(http.StatusUnauthorized, rd)
 		return
 	}
 
-	var promptReq model.MineImagePromptRequest
-	if err := c.BindQuery(&promptReq); err != nil {
-		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "invalid request", nil, gin.H{"error": "prompt not specified"})
-		c.JSON(http.StatusBadRequest, rd)
-		return
-	}
-
-	if err := base.Validate.Struct(&promptReq); err != nil {
-		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "invalid request", nil, err.Error())
+	prompt := c.Query("prompt")
+	if prompt == "" {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, InvalidRequestMessage, nil, makeErrorMap(PromptNotSpecifiedError))
 		c.JSON(http.StatusBadRequest, rd)
 		return
 	}
 
 	if c.ContentType() != "multipart/form-data" {
-		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "invalid request", nil, gin.H{"error": "file is not present"})
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, InvalidRequestMessage, nil, makeErrorMap(FileIsNotPresentError))
 		c.JSON(http.StatusBadRequest, rd)
 		return
 	}
 
 	image, imageHeader, err := c.Request.FormFile("image")
 	if err != nil {
-		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "could not parse file", nil, gin.H{"error": err.Error()})
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, UnableToParseFileMessage, nil, makeErrorMap(err.Error()))
 		c.JSON(http.StatusBadRequest, rd)
 		return
 	}
 	defer image.Close()
 
 	if !validImageFormat(imageHeader.Filename) {
-		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "invalid file", nil, gin.H{"error": "file is not an image"})
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, InvalidFileMessage, nil, makeErrorMap(FileIsNotAnImageError))
 		c.JSON(http.StatusBadRequest, rd)
 		return
 	}
 
-	minedImage, err := mineservice.PromptMineServiceUpload(image, imageHeader.Filename, promptReq.Prompt)
+	minedImage, err := mineservice.PromptMineServiceUpload(image, imageHeader.Filename, prompt)
 	if err != nil {
-		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "undefined error", nil, err.Error())
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, UndefinedErrorMessage, nil, err.Error())
 		c.JSON(http.StatusBadRequest, rd)
 		return
 	}
 
-	rd := utility.BuildSuccessResponse(http.StatusCreated, "mine image successful", minedImage)
+	rd := utility.BuildSuccessResponse(http.StatusCreated, SuccessfulMiningMessage, minedImage)
 	c.JSON(http.StatusOK, rd)
 
+}
+
+func (base *Controller) PromptMineImageUrl(c *gin.Context) {
+
+	err := isTokenVerified(c)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusUnauthorized, FailedStatus, VerifiedTokenMessage, nil, makeErrorMap(err.Error()))
+		c.JSON(http.StatusUnauthorized, rd)
+		return
+	}
+
+	var req model.MineImageUrlRequest
+
+	err = c.Bind(&req)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, UnableToBindUrlMessage, nil, err.Error())
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	err = base.Validate.Struct(&req)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, InvalidUrlMessage, nil, nil)
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	prompt := c.Query("prompt")
+	if prompt == "" {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, InvalidRequestMessage, nil, makeErrorMap(PromptNotSpecifiedError))
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	response, err := http.Get(req.Url)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, UnableToFetchImageFromUrlMessage, nil, err.Error())
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	var image = response.Body
+	defer image.Close()
+
+	filename := getFileName(req.Url)
+
+	if !validImageFormat(filename) {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, InvalidFileMessage, nil, makeErrorMap(FileIsNotAnImageError))
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	minedImage, err := mineservice.PromptMineServiceUpload(image, filename, prompt)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, FailedStatus, UndefinedErrorMessage, nil, err.Error())
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	rd := utility.BuildSuccessResponse(http.StatusCreated, SuccessfulMiningMessage, minedImage)
+	c.JSON(http.StatusOK, rd)
+
+}
+
+func isTokenVerified(c *gin.Context) (err error) {
+	secretKey := config.GetConfig().Server.Secret
+	token := utility.ExtractToken(c)
+	_, err = utility.GetKey("id", token, secretKey)
+	return err
+}
+
+func makeErrorMap(errorMesage string) gin.H {
+	errorMap := gin.H{"error": errorMesage}
+	return errorMap
 }

--- a/pkg/router/mine-service.go
+++ b/pkg/router/mine-service.go
@@ -16,6 +16,7 @@ func MineServiceUpload(r *gin.Engine, validate *validator.Validate, ApiVersion s
 	{
 		authUrl.POST("/mine-service/upload", mineservice.MineImageUpload)
 		authUrl.POST("/mine-service/upload-prompt", mineservice.PromptMineImageUpload)
+		authUrl.POST("/mine-service/url-prompt", mineservice.PromptMineImageUrl)
 		authUrl.POST("/mine-service/url", mineservice.MineImageUrl)
 		authUrl.GET("/mine-service/get-all", mineservice.GetMinedImages)
 	}


### PR DESCRIPTION
- Allows a user to check if a prompt exists in an image gotten from an image url
- Refactored the error messages into constants
- Refactored the token verification code to use a private method to check if the token is valid
- Removed the need for a struct for the prompt you can easily check for prompt using gin's Query method

Postman image to show that endpoint works 
![image](https://user-images.githubusercontent.com/59811608/203979348-e9763971-1ff7-4634-895b-74a5e5b4aa8f.png)

Refactored code in the upload-prompt url so I included this
![image](https://user-images.githubusercontent.com/59811608/203979447-6db46634-f8ce-45ef-9b68-5b82326bdebf.png)
