### PR TITLE
fix: change go version to 1.18 in go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/workshopapps/pictureminer.api
 
-go 1.19
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.44.145


### PR DESCRIPTION
### fix: change go version to 1.18 in go.mod file

This is a fix to solve the version limitation while deploying from the DevOps engineer