### PR TITLE
feat(BE-53): Create demo mine image endpoint.

### DIFF
--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -14,5 +14,3 @@ s3:
   BucketName : "miner-pictures"
 python: 
   microservicehost: "https://yiowpv.deta.dev/api/microservice/content"
-  # Change when the microservice host for prompt is available
-  microserviceprompthost: "https://yiowpv.deta.dev/api/microservice/content"

--- a/config-sample.yaml
+++ b/config-sample.yaml
@@ -13,4 +13,4 @@ s3:
   AWSSecretAccessKey : "yepL/xP02oCuadGiXnWWkaKF5PP4ORZKKBxNDRDy"
   BucketName : "miner-pictures"
 python: 
-  microservicehost: "https://yiowpv.deta.dev/api/microservice/content"
+  microservicehost: "http://178.128.242.94/caption-generator"

--- a/internal/config/microservice.go
+++ b/internal/config/microservice.go
@@ -1,6 +1,5 @@
 package config
 
 type MicroserviceConfiguration struct {
-	MicroserviceHost       string
-	MicroservicePromptHost string
+	MicroserviceHost string
 }

--- a/internal/model/mined_image.go
+++ b/internal/model/mined_image.go
@@ -18,8 +18,8 @@ type MinedImage struct {
 }
 
 type MineImageResponse struct {
-	ImageName    string    `bson:"image_name" json:"image_name"`
-	ImagePath    string    `bson:"image_path" json:"image_path"`
+	ImageName    string    `bson:"image_name" json:"image_name,omitempty"`
+	ImagePath    string    `bson:"image_path" json:"image_path,omitempty"`
 	TextContent  string    `bson:"text_content" json:"text_content"`
 	DateCreated  time.Time `bson:"date_created" json:"date_created"`
 	DateModified time.Time `bson:"date_modified" json:"date_modified"`

--- a/pkg/repository/microservice/microservice.go
+++ b/pkg/repository/microservice/microservice.go
@@ -13,12 +13,10 @@ import (
 	"github.com/workshopapps/pictureminer.api/internal/model"
 )
 
-
-
 func GetImageContent(file io.ReadCloser, filename string) (*model.MicroserviceResponse, error) {
 	microserviceHost := config.GetConfig().Python.MicroserviceHost
 
-	req, err := SetupMultipartRequest(file, microserviceHost, filename, "")
+	req, err := SetupMultipartRequest(file, microserviceHost, filename)
 	if err != nil {
 		return nil, err
 	}
@@ -44,36 +42,7 @@ func GetImageContent(file io.ReadCloser, filename string) (*model.MicroserviceRe
 	return &content, nil
 }
 
-func GetImagePromptResponse(file io.ReadCloser, filename, prompt string) (*model.MicroservicePromptResponse, error) {
-	microserviceHost := config.GetConfig().Python.MicroservicePromptHost
-
-	req, err := SetupMultipartRequest(file, microserviceHost, filename, prompt)
-	if err != nil {
-		return nil, err
-	}
-
-	client := &http.Client{Timeout: 120 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("%s", resp.Body)
-	}
-
-	var content model.MicroservicePromptResponse
-	err = json.NewDecoder(resp.Body).Decode(&content)
-	if err != nil {
-		return nil, err
-	}
-
-	return &content, nil
-}
-
-func SetupMultipartRequest(file io.ReadCloser, microserviceHost, filename string, prompt string) (*http.Request, error) {
+func SetupMultipartRequest(file io.ReadCloser, microserviceHost, filename string) (*http.Request, error) {
 	defer file.Close()
 
 	body := &bytes.Buffer{}
@@ -87,10 +56,6 @@ func SetupMultipartRequest(file io.ReadCloser, microserviceHost, filename string
 	err = writer.Close()
 	if err != nil {
 		return nil, err
-	}
-
-	if prompt != "" {
-		microserviceHost += "?prompt=" + prompt
 	}
 
 	req, err := http.NewRequest("POST", microserviceHost, body)

--- a/pkg/router/mine-service.go
+++ b/pkg/router/mine-service.go
@@ -9,7 +9,7 @@ import (
 	"github.com/workshopapps/pictureminer.api/utility"
 )
 
-func MineServiceUpload(r *gin.Engine, validate *validator.Validate, ApiVersion string, logger *utility.Logger) *gin.Engine {
+func MineService(r *gin.Engine, validate *validator.Validate, ApiVersion string, logger *utility.Logger) *gin.Engine {
 	mineservice := mineservice.Controller{Validate: validate, Logger: logger}
 
 	authUrl := r.Group(fmt.Sprintf("/api/%v", ApiVersion))
@@ -17,6 +17,7 @@ func MineServiceUpload(r *gin.Engine, validate *validator.Validate, ApiVersion s
 		authUrl.POST("/mine-service/upload", mineservice.MineImageUpload)
 		authUrl.POST("/mine-service/url", mineservice.MineImageUrl)
 		authUrl.GET("/mine-service/get-all", mineservice.GetMinedImages)
+		authUrl.POST("/mine-service/demo", mineservice.DemoMineImage)
 	}
 	return r
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -9,6 +9,7 @@ import (
 	"github.com/workshopapps/pictureminer.api/pkg/middleware"
 	"github.com/workshopapps/pictureminer.api/utility"
 )
+
 func Setup(validate *validator.Validate, logger *utility.Logger) *gin.Engine {
 	r := gin.New()
 
@@ -23,7 +24,7 @@ func Setup(validate *validator.Validate, logger *utility.Logger) *gin.Engine {
 	ApiVersion := "v1"
 	Health(r, validate, ApiVersion, logger)
 	Auth(r, validate, ApiVersion, logger)
-	MineServiceUpload(r, validate, ApiVersion, logger)
+	MineService(r, validate, ApiVersion, logger)
 	Admin(r, validate, ApiVersion, logger)
 	SwaggerDocs(r, ApiVersion)
 

--- a/service/mine-service/mine-service.go
+++ b/service/mine-service/mine-service.go
@@ -19,6 +19,23 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+func DemoMineImage(image io.ReadCloser, filename string) (*model.MineImageResponse, error) {
+	content, err := microservice.GetImageContent(image, filename)
+	if err != nil {
+		return nil, err
+	}
+
+	time := time.Now()
+	response := &model.MineImageResponse{
+		ImageName:    filename,
+		TextContent:  content.Content,
+		DateCreated:  time,
+		DateModified: time,
+	}
+
+	return response, nil
+}
+
 func MineServiceUpload(userId interface{}, image io.ReadCloser, filename string) (*model.MineImageResponse, error) {
 	id, ok := userId.(string)
 	if !ok {


### PR DESCRIPTION
### Endpoint

- Demo endpoint for a user to test the API on visiting the website landing page
- Accepts image as a multipart/form-data
- Mines image and returns the response

### Linear ticket

- https://linear.app/team-descripto/issue/BE-53/create-demo-mine-image-endpoint

### Demo
![Screenshot from 2022-12-02 12-23-17](https://user-images.githubusercontent.com/63949797/205282573-f3be5de4-30cb-48b0-9887-f13d3612d7e5.png)

