### PR TITLE
feat(BE-54) Create endpoint to update user info

### DIFF
--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -43,4 +43,7 @@ type UpdateUser struct{
 	LastName		string		`bson:"last_name" json:"last_name"`
 	Email			string		`bson:"email" json:"email" validate:"required"`
 	UserName 		string		`bson:"username" json:"username"`
+	CurrentPassword string		`bson:"current_password" json:"current_password"`
+	NewPassword     string		`bson:"new_password" json:"new_password"`
+	ConfirmPassword string		`bson:"confirm_password" json:"confirm_password"`
 }

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -37,3 +37,10 @@ type PasswordReset struct {
 type PasswordForgot struct {
 	Email       	string `bson:"email" json:"email" validate:"required"`
 }
+
+type UpdateUser struct{
+	FirstName 		string		`bson:"first_name" json:"first_name"`
+	LastName		string		`bson:"last_name" json:"last_name"`
+	Email			string		`bson:"email" json:"email" validate:"required"`
+	UserName 		string		`bson:"username" json:"username"`
+}

--- a/pkg/handler/user/user.go
+++ b/pkg/handler/user/user.go
@@ -137,3 +137,31 @@ func (base *Controller) ForgotPassword(c *gin.Context) {
 	object := utility.BuildSuccessResponse(200, "password reset success", gin.H{})
 	c.JSON(200, object)
 }
+
+func (base *Controller) UpdateUser(c *gin.Context) {
+	var reqBody model.UpdateUser
+
+	err := c.Bind(&reqBody)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusInternalServerError, "error", "Unable to bind user login details", err, nil)
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	err = base.Validate.Struct(&reqBody)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "error", "Validation failed", utility.ValidationResponse(err, base.Validate), nil)
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	result,err := user.UpdateUserService(reqBody)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "error", "Validation failed", utility.ValidationResponse(err, base.Validate), nil)
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	object := utility.BuildSuccessResponse(200, "User update successful", result)
+	c.JSON(200, object)
+}

--- a/pkg/router/user.go
+++ b/pkg/router/user.go
@@ -20,6 +20,7 @@ func Auth(r *gin.Engine, validate *validator.Validate, ApiVersion string, logger
 		authUrl.POST("/signup", auth.Signup)
 		authUrl.POST("/reset", auth.ResetPassword)
 		authUrl.POST("/forgot-password", auth.ForgotPassword)
+		authUrl.POST("/update-user", auth.UpdateUser)
 	}
 	return r
 }

--- a/pkg/router/user.go
+++ b/pkg/router/user.go
@@ -20,7 +20,7 @@ func Auth(r *gin.Engine, validate *validator.Validate, ApiVersion string, logger
 		authUrl.POST("/signup", auth.Signup)
 		authUrl.POST("/reset", auth.ResetPassword)
 		authUrl.POST("/forgot-password", auth.ForgotPassword)
-		authUrl.POST("/update-user", auth.UpdateUser)
+		authUrl.PUT("/update-user", auth.UpdateUser)
 	}
 	return r
 }

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -13,6 +13,7 @@ import (
 	"github.com/workshopapps/pictureminer.api/utility"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -148,4 +149,26 @@ func getUserFromDB(email string) (model.User, error) {
 
 func isValidPassword(userPassword, providedPassword string) bool {
 	return bcrypt.CompareHashAndPassword([]byte(userPassword), []byte(providedPassword)) == nil
+}
+
+
+func UpdateUserService(user model.UpdateUser) (*mongo.UpdateResult, error) {
+	database := config.GetConfig().Mongodb.Database
+	userCollection := mongodb.GetCollection(mongodb.Connection(), database, constants.UserCollection)
+
+	filter := bson.M{"email": user.Email}
+
+	update := bson.D{{Key: "$set", Value: bson.D{
+		{Key: "first_name", Value: user.FirstName},
+		{Key: "last_name", Value: user.LastName},
+		{Key: "email", Value: user.Email},
+		{Key: "username", Value: user.UserName}} }}
+
+	result, err := userCollection.UpdateOne(context.TODO(), filter, update)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result,nil
 }


### PR DESCRIPTION
**UPDATE USER ENDPOINT**
Users can now update the following fields:

-  FirstName
- LastName
- Email
- Username
- Password

**Linear Ticket**
https://linear.app/team-descripto/issue/BE-54/create-endpoint-to-update-user-info

**ONLY EMAIL IS REQUIRED TO MAKE UPDATES BUT IF USER WANTS TO CHANGE PASSWORD the following fields are required**

- **current password**
- **new_password**
- **comfirm_password**
