### PR TITLE
feat(BE-83): swagger-testreset-password

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -183,6 +183,37 @@ const docTemplate = `{
                 }
             }
         },
+        "/reset": {
+            "post": {
+                "description": "Send a post request to reset th password of the user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Resests the password of the user",
+                "parameters": [
+                    {
+                        "description": "Ping JSON",
+                        "name": "ping",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.PasswordReset"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/signup": {
             "post": {
                 "description": "Creates an account for a new user",
@@ -252,6 +283,25 @@ const docTemplate = `{
             ],
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.PasswordReset": {
+            "type": "object",
+            "required": [
+                "confirm_password",
+                "email",
+                "password"
+            ],
+            "properties": {
+                "confirm_password": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -179,6 +179,37 @@
                 }
             }
         },
+        "/reset": {
+            "post": {
+                "description": "Send a post request to reset th password of the user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Resests the password of the user",
+                "parameters": [
+                    {
+                        "description": "Ping JSON",
+                        "name": "ping",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.PasswordReset"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/signup": {
             "post": {
                 "description": "Creates an account for a new user",
@@ -248,6 +279,25 @@
             ],
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.PasswordReset": {
+            "type": "object",
+            "required": [
+                "confirm_password",
+                "email",
+                "password"
+            ],
+            "properties": {
+                "confirm_password": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -26,6 +26,19 @@ definitions:
     required:
     - email
     type: object
+  model.PasswordReset:
+    properties:
+      confirm_password:
+        type: string
+      email:
+        type: string
+      password:
+        type: string
+    required:
+    - confirm_password
+    - email
+    - password
+    type: object
   model.Ping:
     properties:
       email:
@@ -236,6 +249,26 @@ paths:
           schema:
             $ref: '#/definitions/model.UserLogin'
       summary: Login User
+      tags:
+      - users
+  /reset:
+    post:
+      description: Send a post request to reset th password of the user
+      parameters:
+      - description: Ping JSON
+        in: body
+        name: ping
+        required: true
+        schema:
+          $ref: '#/definitions/model.PasswordReset'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/utility.Response'
+      summary: Resests the password of the user
       tags:
       - users
   /signup:

--- a/pkg/handler/user/user.go
+++ b/pkg/handler/user/user.go
@@ -90,6 +90,14 @@ func (base *Controller) Login(c *gin.Context) {
 	c.JSON(200, object)
 }
 
+// Post             godoc
+// @Summary     Resests the password of the user
+// @Description Send a post request to reset th password of the user
+// @Tags        users
+// @Produce     json
+// @Param       ping body     model.PasswordReset true "Ping JSON"
+// @Success     200  {object} utility.Response
+// @Router      /reset [post]
 func (base *Controller) ResetPassword(c *gin.Context) {
 	// bind password reset details to User struct
 	var reqBody model.PasswordReset


### PR DESCRIPTION
## [Liner ticket](https://linear.app/team-discripto/issue/BE-83/swagger-testreset-password)
### Task: Create a swagger test documentation for testing reset password details.
### Details:
When initiated,The testing should be able to reset password the documentation.
How to test: If running locally or live, visit the endpoint (http://localhost:9000/api/v1/reset) and provide the neccesary parameters in your request body 
```json
{
  "confirm_password": "string",
  "email": "string",
  "password": "string"
}
```
The password of of the user identified by the request body should immediately be reset.

P.s when testing live, visit (https://discripto.hng.tech/api1/api/v1/reset) and provide the neccesary parameters in your request body 
```json
{
  "confirm_password": "string",
  "email": "string",
  "password": "string"
}
```