### PR TITLE
feat(BE-80): swagger test single image mining

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -183,6 +183,37 @@ const docTemplate = `{
                 }
             }
         },
+        "/reset": {
+            "post": {
+                "description": "Send a post request to reset th password of the user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Resests the password of the user",
+                "parameters": [
+                    {
+                        "description": "Ping JSON",
+                        "name": "ping",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.PasswordReset"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/signup": {
             "post": {
                 "description": "Creates an account for a new user",
@@ -252,6 +283,25 @@ const docTemplate = `{
             ],
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.PasswordReset": {
+            "type": "object",
+            "required": [
+                "confirm_password",
+                "email",
+                "password"
+            ],
+            "properties": {
+                "confirm_password": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -183,6 +183,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/mine-service/upload": {
+            "post": {
+                "description": "Send a post request containing a file an receives a response of its context content.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Mine-Service"
+                ],
+                "summary": "Mines an uploaded image",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "image",
+                        "name": "os.File",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.MineImageResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/reset": {
             "post": {
                 "description": "Send a post request to reset th password of the user",
@@ -209,35 +238,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/utility.Response"
-                        }
-                    }
-                }
-            }
-        },
-        "/mine-service/upload": {
-            "post": {
-                "description": "Send a post request containing a file an receives a response of its context content.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "Mine-Service"
-                ],
-                "summary": "Mines an uploaded image",
-                "parameters": [
-                    {
-                        "type": "file",
-                        "description": "image",
-                        "name": "os.File",
-                        "in": "formData",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.MineImageResponse"
                         }
                     }
                 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -183,6 +183,35 @@ const docTemplate = `{
                 }
             }
         },
+        "/mine-service/upload": {
+            "post": {
+                "description": "Send a post request containing a file an receives a response of its context content.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Mine-Service"
+                ],
+                "summary": "Mines an uploaded image",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "image",
+                        "name": "os.File",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.MineImageResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/signup": {
             "post": {
                 "description": "Creates an account for a new user",
@@ -216,6 +245,26 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "model.MineImageResponse": {
+            "type": "object",
+            "properties": {
+                "date_created": {
+                    "type": "string"
+                },
+                "date_modified": {
+                    "type": "string"
+                },
+                "image_name": {
+                    "type": "string"
+                },
+                "image_path": {
+                    "type": "string"
+                },
+                "text_content": {
+                    "type": "string"
+                }
+            }
+        },
         "model.MinedImage": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -179,6 +179,37 @@
                 }
             }
         },
+        "/reset": {
+            "post": {
+                "description": "Send a post request to reset th password of the user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Resests the password of the user",
+                "parameters": [
+                    {
+                        "description": "Ping JSON",
+                        "name": "ping",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.PasswordReset"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/signup": {
             "post": {
                 "description": "Creates an account for a new user",
@@ -248,6 +279,25 @@
             ],
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.PasswordReset": {
+            "type": "object",
+            "required": [
+                "confirm_password",
+                "email",
+                "password"
+            ],
+            "properties": {
+                "confirm_password": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "password": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -179,6 +179,35 @@
                 }
             }
         },
+        "/mine-service/upload": {
+            "post": {
+                "description": "Send a post request containing a file an receives a response of its context content.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Mine-Service"
+                ],
+                "summary": "Mines an uploaded image",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "image",
+                        "name": "os.File",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.MineImageResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/reset": {
             "post": {
                 "description": "Send a post request to reset th password of the user",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -179,6 +179,35 @@
                 }
             }
         },
+        "/mine-service/upload": {
+            "post": {
+                "description": "Send a post request containing a file an receives a response of its context content.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Mine-Service"
+                ],
+                "summary": "Mines an uploaded image",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "image",
+                        "name": "os.File",
+                        "in": "formData",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.MineImageResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/signup": {
             "post": {
                 "description": "Creates an account for a new user",
@@ -212,6 +241,26 @@
         }
     },
     "definitions": {
+        "model.MineImageResponse": {
+            "type": "object",
+            "properties": {
+                "date_created": {
+                    "type": "string"
+                },
+                "date_modified": {
+                    "type": "string"
+                },
+                "image_name": {
+                    "type": "string"
+                },
+                "image_path": {
+                    "type": "string"
+                },
+                "text_content": {
+                    "type": "string"
+                }
+            }
+        },
         "model.MinedImage": {
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -26,6 +26,19 @@ definitions:
     required:
     - email
     type: object
+  model.PasswordReset:
+    properties:
+      confirm_password:
+        type: string
+      email:
+        type: string
+      password:
+        type: string
+    required:
+    - confirm_password
+    - email
+    - password
+    type: object
   model.Ping:
     properties:
       email:
@@ -236,6 +249,26 @@ paths:
           schema:
             $ref: '#/definitions/model.UserLogin'
       summary: Login User
+      tags:
+      - users
+  /reset:
+    post:
+      description: Send a post request to reset th password of the user
+      parameters:
+      - description: Ping JSON
+        in: body
+        name: ping
+        required: true
+        schema:
+          $ref: '#/definitions/model.PasswordReset'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/utility.Response'
+      summary: Resests the password of the user
       tags:
       - users
   /signup:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,18 @@
 basePath: /api/v1/
 definitions:
+  model.MineImageResponse:
+    properties:
+      date_created:
+        type: string
+      date_modified:
+        type: string
+      image_name:
+        type: string
+      image_path:
+        type: string
+      text_content:
+        type: string
+    type: object
   model.MinedImage:
     properties:
       dateCreated:
@@ -238,6 +251,26 @@ paths:
       summary: Login User
       tags:
       - users
+  /mine-service/upload:
+    post:
+      description: Send a post request containing a file an receives a response of
+        its context content.
+      parameters:
+      - description: image
+        in: formData
+        name: os.File
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.MineImageResponse'
+      summary: Mines an uploaded image
+      tags:
+      - Mine-Service
   /signup:
     post:
       description: Creates an account for a new user

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -264,6 +264,26 @@ paths:
       summary: Login User
       tags:
       - users
+  /mine-service/upload:
+    post:
+      description: Send a post request containing a file an receives a response of
+        its context content.
+      parameters:
+      - description: image
+        in: formData
+        name: os.File
+        required: true
+        type: file
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.MineImageResponse'
+      summary: Mines an uploaded image
+      tags:
+      - Mine-Service
   /reset:
     post:
       description: Send a post request to reset th password of the user

--- a/pkg/handler/mine-service/mine-service.go
+++ b/pkg/handler/mine-service/mine-service.go
@@ -51,6 +51,14 @@ func (base *Controller) DemoMineImage(c *gin.Context) {
 	c.JSON(http.StatusOK, rd)
 }
 
+// Post             godoc
+// @Summary     Mines an uploaded image
+// @Description Send a post request containing a file an receives a response of its context content.
+// @Tags        Mine-Service
+// @Produce     json
+// @Param       @Param os.File formData file true "image"
+// @Success     200  {object} model.MineImageResponse
+// @Router      /mine-service/upload [post]
 func (base *Controller) MineImageUpload(c *gin.Context) {
 
 	secretKey := config.GetConfig().Server.Secret

--- a/pkg/handler/user/user.go
+++ b/pkg/handler/user/user.go
@@ -90,6 +90,14 @@ func (base *Controller) Login(c *gin.Context) {
 	c.JSON(200, object)
 }
 
+// Post             godoc
+// @Summary     Resests the password of the user
+// @Description Send a post request to reset th password of the user
+// @Tags        users
+// @Produce     json
+// @Param       ping body     model.PasswordReset true "Ping JSON"
+// @Success     200  {object} utility.Response
+// @Router      /reset [post]
 func (base *Controller) ResetPassword(c *gin.Context) {
 	// bind password reset details to User struct
 	var reqBody model.PasswordReset


### PR DESCRIPTION
## [Liner ticket](https://linear.app/team-discripto/issue/BE-80/swagger-test-test-image-mining)

### Task: Create a swagger test documentation for testing mined images on the user side
### Details:
When initiated,The testing should be able to accept picture input or file and output picture description.
How to test: If running locally or live, visit the endpoint (http://localhost:9000/api/v1/mine-sevice/upload)

<img width="1280" alt="Screenshot 2022-12-04 at 09 26 51" src="https://user-images.githubusercontent.com/86890896/205481417-4d158c73-f9ba-4316-84f2-3250193601a5.png">


P.s when testing live visit (https://discripto.hng.tech/api1/api/v1/mine-service/upload)

You must be logged in to test this endpoint

A response containing the text context/content of the image should be returned.