### PR TITLE
feat: write swagger documentation for process batch api

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -121,6 +121,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/batch-service/process-batch-api": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Process a list of images as a batch",
+                "tags": [
+                    "batch-api"
+                ],
+                "summary": "Processes a batch of images",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "json",
+                        "name": "json",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "csv",
+                        "name": "csv",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/forgot-password": {
             "post": {
                 "description": "Send a dummy post request to test the status of the server",
@@ -191,9 +228,6 @@ const docTemplate = `{
                     }
                 ],
                 "description": "Send a post request containing a file an receives a response of its context content.",
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "Mine-Service"
                 ],
@@ -202,7 +236,7 @@ const docTemplate = `{
                     {
                         "type": "file",
                         "description": "image",
-                        "name": "os.File",
+                        "name": "image",
                         "in": "formData",
                         "required": true
                     }
@@ -211,7 +245,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/model.MineImageResponse"
+                            "$ref": "#/definitions/utility.Response"
                         }
                     }
                 }
@@ -312,26 +346,6 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "model.MineImageResponse": {
-            "type": "object",
-            "properties": {
-                "date_created": {
-                    "type": "string"
-                },
-                "date_modified": {
-                    "type": "string"
-                },
-                "image_name": {
-                    "type": "string"
-                },
-                "image_path": {
-                    "type": "string"
-                },
-                "text_content": {
-                    "type": "string"
-                }
-            }
-        },
         "model.MinedImage": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -117,6 +117,43 @@
                 }
             }
         },
+        "/batch-service/process-batch-api": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Process a list of images as a batch",
+                "tags": [
+                    "batch-api"
+                ],
+                "summary": "Processes a batch of images",
+                "parameters": [
+                    {
+                        "type": "file",
+                        "description": "json",
+                        "name": "json",
+                        "in": "formData",
+                        "required": true
+                    },
+                    {
+                        "type": "file",
+                        "description": "csv",
+                        "name": "csv",
+                        "in": "formData"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/forgot-password": {
             "post": {
                 "description": "Send a dummy post request to test the status of the server",
@@ -187,9 +224,6 @@
                     }
                 ],
                 "description": "Send a post request containing a file an receives a response of its context content.",
-                "produces": [
-                    "application/json"
-                ],
                 "tags": [
                     "Mine-Service"
                 ],
@@ -198,7 +232,7 @@
                     {
                         "type": "file",
                         "description": "image",
-                        "name": "os.File",
+                        "name": "image",
                         "in": "formData",
                         "required": true
                     }
@@ -207,7 +241,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/model.MineImageResponse"
+                            "$ref": "#/definitions/utility.Response"
                         }
                     }
                 }
@@ -308,26 +342,6 @@
         }
     },
     "definitions": {
-        "model.MineImageResponse": {
-            "type": "object",
-            "properties": {
-                "date_created": {
-                    "type": "string"
-                },
-                "date_modified": {
-                    "type": "string"
-                },
-                "image_name": {
-                    "type": "string"
-                },
-                "image_path": {
-                    "type": "string"
-                },
-                "text_content": {
-                    "type": "string"
-                }
-            }
-        },
         "model.MinedImage": {
             "type": "object",
             "properties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,18 +1,5 @@
 basePath: /api/v1/
 definitions:
-  model.MineImageResponse:
-    properties:
-      date_created:
-        type: string
-      date_modified:
-        type: string
-      image_name:
-        type: string
-      image_path:
-        type: string
-      text_content:
-        type: string
-    type: object
   model.MinedImage:
     properties:
       dateCreated:
@@ -240,6 +227,29 @@ paths:
       summary: Checks the status of the server
       tags:
       - health
+  /batch-service/process-batch-api:
+    post:
+      description: Process a list of images as a batch
+      parameters:
+      - description: json
+        in: formData
+        name: json
+        required: true
+        type: file
+      - description: csv
+        in: formData
+        name: csv
+        type: file
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/utility.Response'
+      security:
+      - BearerAuth: []
+      summary: Processes a batch of images
+      tags:
+      - batch-api
   /forgot-password:
     post:
       description: Send a dummy post request to test the status of the server
@@ -287,16 +297,14 @@ paths:
       parameters:
       - description: image
         in: formData
-        name: os.File
+        name: image
         required: true
         type: file
-      produces:
-      - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/model.MineImageResponse'
+            $ref: '#/definitions/utility.Response'
       security:
       - BearerAuth: []
       summary: Mines an uploaded image

--- a/pkg/handler/batch-service/process-batch.go
+++ b/pkg/handler/batch-service/process-batch.go
@@ -17,6 +17,15 @@ type Controller struct {
 	Logger   *utility.Logger
 }
 
+// ProcessBatchAPI godoc
+// @Summary      Processes a batch of images
+// @Description  Process a list of images as a batch
+// @Tags         batch-api
+// @Param       json formData file true "json"
+// @Param       csv formData file false "csv"
+// @Success      200   {object}  utility.Response
+// @Router       /batch-service/process-batch-api [post]
+// @Security BearerAuth
 func (base *Controller) ProcessBatchAPI(c *gin.Context) {
 	secretKey := config.GetConfig().Server.Secret
 	token := utility.ExtractToken(c)

--- a/pkg/handler/mine-service/mine-service.go
+++ b/pkg/handler/mine-service/mine-service.go
@@ -9,8 +9,8 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/workshopapps/pictureminer.api/internal/config"
 	"github.com/workshopapps/pictureminer.api/internal/model"
-	mineservice "github.com/workshopapps/pictureminer.api/service/mine-service"
 	batchservice "github.com/workshopapps/pictureminer.api/service/batch-service"
+	mineservice "github.com/workshopapps/pictureminer.api/service/mine-service"
 	"github.com/workshopapps/pictureminer.api/utility"
 )
 
@@ -55,9 +55,8 @@ func (base *Controller) DemoMineImage(c *gin.Context) {
 // @Summary     Mines an uploaded image
 // @Description Send a post request containing a file an receives a response of its context content.
 // @Tags        Mine-Service
-// @Produce     json
-// @Param       @Param os.File formData file true "image"
-// @Success     200  {object} model.MineImageResponse
+// @Param       image formData file true "image"
+// @Success     200  {object} utility.Response
 // @Router      /mine-service/upload [post]
 // @Security BearerAuth
 func (base *Controller) MineImageUpload(c *gin.Context) {
@@ -210,6 +209,5 @@ func (base *Controller) DownloadCsv(c *gin.Context) {
 
 	c.File("filename.csv")
 	defer os.Remove("filename.csv")
-	
 
 }


### PR DESCRIPTION
### Write swagger documentation for process batch api

- This feat includes writing swagger documentation for the core process batch api endpoint.
- This feat also includes fixing errors from the mine service upload api swagger documentation.