### PR TITLE
refactored update user endpoint

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -281,7 +281,7 @@ const docTemplate = `{
         },
         "/update-user": {
             "patch": {
-                "description": "Updates a User's information - email,firstName,lastName,password- Bearer token and email required",
+                "description": "Updates a User's information - email,firstName,lastName,password - Bearer token required - To change password, current_password, new_password and confirm_password(repeat of the new password) are required",
                 "produces": [
                     "application/json"
                 ],
@@ -302,10 +302,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.UserLogin"
-                        }
+                        "description": "OK"
                     }
                 }
             }
@@ -401,9 +398,6 @@ const docTemplate = `{
         },
         "model.UpdateUser": {
             "type": "object",
-            "required": [
-                "email"
-            ],
             "properties": {
                 "confirm_password": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -277,7 +277,7 @@
         },
         "/update-user": {
             "patch": {
-                "description": "Updates a User's information - email,firstName,lastName,password- Bearer token and email required",
+                "description": "Updates a User's information - email,firstName,lastName,password - Bearer token required - To change password, current_password, new_password and confirm_password(repeat of the new password) are required",
                 "produces": [
                     "application/json"
                 ],
@@ -298,10 +298,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/model.UserLogin"
-                        }
+                        "description": "OK"
                     }
                 }
             }
@@ -397,9 +394,6 @@
         },
         "model.UpdateUser": {
             "type": "object",
-            "required": [
-                "email"
-            ],
             "properties": {
                 "confirm_password": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -73,8 +73,6 @@ definitions:
         type: string
       username:
         type: string
-    required:
-    - email
     type: object
   model.User:
     properties:
@@ -344,8 +342,9 @@ paths:
       - users
   /update-user:
     patch:
-      description: Updates a User's information - email,firstName,lastName,password-
-        Bearer token and email required
+      description: Updates a User's information - email,firstName,lastName,password
+        - Bearer token required - To change password, current_password, new_password
+        and confirm_password(repeat of the new password) are required
       parameters:
       - description: User Update
         in: body
@@ -358,8 +357,6 @@ paths:
       responses:
         "200":
           description: OK
-          schema:
-            $ref: '#/definitions/model.UserLogin'
       summary: Update User
       tags:
       - users

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -60,7 +60,7 @@ type PasswordForgot struct {
 type UpdateUser struct {
 	FirstName       string `bson:"first_name" json:"first_name"`
 	LastName        string `bson:"last_name" json:"last_name"`
-	Email           string `bson:"email" json:"email" validate:"required"`
+	Email           string `bson:"email" json:"email"`
 	UserName        string `bson:"username" json:"username"`
 	CurrentPassword string `bson:"current_password" json:"current_password"`
 	NewPassword     string `bson:"new_password" json:"new_password"`

--- a/pkg/handler/user/user.go
+++ b/pkg/handler/user/user.go
@@ -215,16 +215,16 @@ func (base *Controller) UpdateProfilePicture(c *gin.Context) {
 
 // Update User          godoc
 // @Summary		Update User
-// @Description Updates a User's information - email,firstName,lastName,password- Bearer token and email required
+// @Description Updates a User's information - email,firstName,lastName,password - Bearer token required - To change password, current_password, new_password and confirm_password(repeat of the new password) are required
 // @Tags        users
 // @Produce     json
 // @Param User body model.UpdateUser true "User Update" model.UserUpdate
-// @Success     200  {object} model.UserLogin
+// @Success     200  
 // @Router      /update-user [patch]
 func (base *Controller) UpdateUser(c *gin.Context) {
 	secretKey := config.GetConfig().Server.Secret
 	token := utility.ExtractToken(c)
-	_, err := utility.GetKey("id", token, secretKey)
+	userId, err := utility.GetKey("id", token, secretKey)
 	if err != nil {
 		rd := utility.BuildErrorResponse(http.StatusUnauthorized, "failed", "could not verify token", nil, gin.H{"error": err.Error()})
 		c.JSON(http.StatusUnauthorized, rd)
@@ -245,7 +245,7 @@ func (base *Controller) UpdateUser(c *gin.Context) {
 		return
 	}
 
-	statusCode, err := user.UpdateUserService(reqBody)
+	statusCode, err := user.UpdateUserService(reqBody,userId)
 	if err != nil {
 		rd := utility.BuildErrorResponse(statusCode, "error", "user update failed", gin.H{"error": err.Error()}, nil)
 		c.JSON(statusCode, rd)

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -193,11 +193,18 @@ func ProfilePictureServiceUpload(userId interface{}, image io.ReadCloser, filena
 
 }
 
-func UpdateUserService(user model.UpdateUser) (int, error) {
+func UpdateUserService(user model.UpdateUser, userId interface{}) (int, error) {
+	string_id,_ := userId.(string)
+	string_id = string_id[10:len(string_id)-2]
+	fmt.Println(string_id)
+	id,_ := primitive.ObjectIDFromHex(string_id)
 	database := config.GetConfig().Mongodb.Database
-	filter := bson.D{{Key: "email", Value: user.Email}}
+	filter := bson.D{{"_id", id}}
+	
 	if len(user.LastName) > 0 {
-		update := bson.M{"$set": bson.M{"last_name": user.LastName}}
+		update := bson.D{
+			{"$set", bson.D{{"last_name", user.LastName}}},
+		}
 		err := UpdateFunc(database, filter, update)
 		if err != nil {
 			return 400, err
@@ -205,7 +212,9 @@ func UpdateUserService(user model.UpdateUser) (int, error) {
 	}
 
 	if len(user.FirstName) > 0 {
-		update := bson.M{"$set": bson.M{"first_name": user.FirstName}}
+		update := bson.D{
+			{"$set", bson.D{{"first_name", user.FirstName}}},
+		}
 		err := UpdateFunc(database, filter, update)
 		if err != nil {
 			return 400, err
@@ -213,7 +222,9 @@ func UpdateUserService(user model.UpdateUser) (int, error) {
 	}
 
 	if len(user.Email) > 0 {
-		update := bson.M{"$set": bson.M{"email": user.Email}}
+		update := bson.D{
+			{"$set", bson.D{{"email", user.Email}}},
+		}
 		err := UpdateFunc(database, filter, update)
 		if err != nil {
 			return 400, err
@@ -221,7 +232,9 @@ func UpdateUserService(user model.UpdateUser) (int, error) {
 	}
 
 	if len(user.UserName) > 0 {
-		update := bson.M{"$set": bson.M{"username": user.UserName}}
+		update := bson.D{
+			{"$set", bson.D{{"username", user.UserName}}},
+		}
 		err := UpdateFunc(database, filter, update)
 		if err != nil {
 			return 400, err
@@ -236,7 +249,9 @@ func UpdateUserService(user model.UpdateUser) (int, error) {
 
 		hash, _ := bcrypt.GenerateFromPassword([]byte(user.NewPassword), 10)
 		user.NewPassword = string(hash)
-		update := bson.M{"$set": bson.M{"password": user.NewPassword}}
+		update :=bson.D{
+			{"$set", bson.D{{"password", user.NewPassword}}},
+		}
 		err = UpdateFunc(database, filter, update)
 		if err != nil {
 			return 400, err
@@ -246,7 +261,7 @@ func UpdateUserService(user model.UpdateUser) (int, error) {
 	return 200, nil
 }
 
-func UpdateFunc(db string, filter bson.D, update bson.M) error {
+func UpdateFunc(db string, filter bson.D, update bson.D) error {
 	userCollection := mongodb.GetCollection(mongodb.Connection(), db, constants.UserCollection)
 	_, err := userCollection.UpdateOne(context.TODO(), filter, update)
 	return err

--- a/service/user/user.go
+++ b/service/user/user.go
@@ -196,7 +196,6 @@ func ProfilePictureServiceUpload(userId interface{}, image io.ReadCloser, filena
 func UpdateUserService(user model.UpdateUser, userId interface{}) (int, error) {
 	string_id,_ := userId.(string)
 	string_id = string_id[10:len(string_id)-2]
-	fmt.Println(string_id)
 	id,_ := primitive.ObjectIDFromHex(string_id)
 	database := config.GetConfig().Mongodb.Database
 	filter := bson.D{{"_id", id}}


### PR DESCRIPTION
**REFACTORED THE UPDATE USER ENDPOINT SO THAT THE EMAIL FIELD IS NOT REQUIRED**
**BEARER TOKEN IS STILL REQUIRED**

**LINEAR TICKET**
https://linear.app/team-discripto/issue/BE-54/create-endpoint-to-update-user-info