### PR TITLE
feat: add endpoint to delete a batch and it's images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 config.yaml
 
 .env
+.idea/
 logs/
 pictureminer.api
 .github/

--- a/pkg/handler/batch-service/process-batch.go
+++ b/pkg/handler/batch-service/process-batch.go
@@ -228,3 +228,28 @@ func (base *Controller) GetBatchImages(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 
 }
+
+func (base *Controller) DeleteBatch(c *gin.Context) {
+
+	secretKey := config.GetConfig().Server.Secret
+	token := utility.ExtractToken(c)
+	_, err := utility.GetKey("id", token, secretKey)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusUnauthorized, "failed", "could not verify token", nil, gin.H{"error": err.Error()})
+		c.JSON(http.StatusUnauthorized, rd)
+		return
+	}
+
+	batchID := c.Param("id")
+
+	err = batchservice.DeleteBatchService(batchID)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "could not delete batch", nil, gin.H{"error": err.Error()})
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	rd := utility.BuildSuccessResponse(http.StatusOK, "delete batch success", gin.H{})
+	c.JSON(http.StatusOK, rd)
+
+}

--- a/pkg/router/batch.go
+++ b/pkg/router/batch.go
@@ -19,6 +19,7 @@ func ProcessBatch(r *gin.Engine, validate *validator.Validate, ApiVersion string
 		authUrl.GET("/batch-service/get-batches", batch.GetBatches)
 		authUrl.POST("/batch-service/process-batch-api", batch.ProcessBatchAPI)
 		authUrl.GET("/batch-service/images/:batch_id", batch.GetBatchImages)
+		authUrl.DELETE("/batch-service/delete/:id", batch.DeleteBatch)
 	}
 
 	return r

--- a/service/batch-service/batch.go
+++ b/service/batch-service/batch.go
@@ -193,6 +193,33 @@ func parseDetails(file io.Reader) (map[string]string, []string, error) {
 	return dMap, body, nil
 }
 
+func DeleteBatchService(batchID string) error {
+	ctx := context.TODO()
+	db := config.GetConfig().Mongodb.Database
+
+	id, err := primitive.ObjectIDFromHex(batchID)
+	if err != nil {
+		return err
+	}
+
+	filter := bson.M{"_id": id}
+	batchCol := mongodb.GetCollection(mongodb.Connection(), db, constants.BatchCollection)
+	_, err = batchCol.DeleteOne(ctx, filter)
+	if err != nil {
+		return err
+	}
+
+	// delete all images in the batch
+	filter = bson.M{"batch_id": id.Hex()}
+	batchImgCol := mongodb.GetCollection(mongodb.Connection(), db, constants.BatchImageCollection)
+	_, err = batchImgCol.DeleteMany(ctx, filter)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func getDetails(file io.Reader) ([]string, []string) {
 	details, body := []string{}, []string{}
 


### PR DESCRIPTION
### Linear link
https://linear.app/team-discripto/issue/BE-67/delete-a-batch-collection

### Task
Create endpoint to delete a batch (batch collection) and all its images from the database.

### Detail
- Get batch id as a path param
- Delete the batch with the id
- Delete all images referencing the batch
- return success response

### Preview
![neww](https://user-images.githubusercontent.com/102928664/205646967-33285f7c-7782-4718-9b9b-6af64c6e3c76.PNG)
