### PR TITLE
added get all subscribed emails

### DIFF
--- a/pkg/handler/admin/admin.go
+++ b/pkg/handler/admin/admin.go
@@ -104,3 +104,19 @@ func (base *Controller) GetAllMinedImages(c *gin.Context) {
 	c.JSON(http.StatusOK, rd)
 
 }
+
+
+func (base *Controller) GetSubscribers(c *gin.Context) {
+
+
+	subscribers, err := admin.GetSubscribers()
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusInternalServerError, "error", err.Error(), err, nil)
+		c.JSON(http.StatusInternalServerError, rd)
+		return
+	}
+
+	rd := utility.BuildSuccessResponse(http.StatusOK, "success", gin.H{"data": subscribers})
+	c.JSON(http.StatusOK, rd)
+
+}

--- a/pkg/router/admin.go
+++ b/pkg/router/admin.go
@@ -18,7 +18,8 @@ func Admin(r *gin.Engine, validate *validator.Validate, ApiVersion string, logge
 		adminUrl.GET("/admin/users", admin.GetUsers)
 		adminUrl.GET("/admin/mined-images", admin.GetAllMinedImages)
 		adminUrl.DELETE("/admin/users/:email", admin.DeleteUser)
-		
+		adminUrl.GET("/admin/subscribers", admin.GetSubscribers)
+
 	}
 	return r
 }

--- a/service/admin/admin.go
+++ b/service/admin/admin.go
@@ -55,3 +55,19 @@ func GetMinedImages() ([]model.MinedImage, error) {
 
 	return minedImages, nil
 }
+
+
+func GetSubscribers() ([]model.SubscriberEmail , error){
+
+	ctx := context.TODO()
+	cursor, err := mongodb.SelectFromCollection(ctx, config.GetConfig().Mongodb.Database, constants.SubscriberEmail, bson.M{})
+
+	if err != nil {
+		return []model.SubscriberEmail{}, err
+	}
+
+	var subscribers []model.SubscriberEmail
+	cursor.All(ctx, &subscribers)
+
+	return subscribers, nil
+}


### PR DESCRIPTION
Feat BE-96 

Admin can be able to get all subscribed emails

it will come in the format

`{
"id" : Object(ID)
"email": string
"status": bool
}`

Linear ticked link
https://linear.app/team-discripto/issue/BE-96/admin-get-list-of-subscribed-emails

