### PR TITLE
Feat(BE-92): implementation of the reviews icon

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -44,34 +44,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/admin/users": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List all users",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "admin"
-                ],
-                "summary": "List all users",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.User"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/health": {
             "get": {
                 "description": "Responds with the server status as JSON.",
@@ -151,6 +123,66 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/feedback": {
+            "post": {
+                "description": "Send feedback to discripto",
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Sends feedback to discripto",
+                "parameters": [
+                    {
+                        "description": "Create feedback",
+                        "name": "Feedback",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.FeedbackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.FeedbackCreatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/feedback/all": {
+            "get": {
+                "description": "Gets all feedback sent to discripto",
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Gets all feedback sent discripto",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.Feedback"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/utility.Response"
                         }
@@ -374,6 +406,54 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "model.Feedback": {
+            "type": "object",
+            "properties": {
+                "date_created": {
+                    "type": "string"
+                },
+                "feedback": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "image_key": {
+                    "type": "string"
+                },
+                "is_helpful": {
+                    "type": "boolean"
+                },
+                "reviewer_email": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.FeedbackCreatedResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.FeedbackRequest": {
+            "type": "object",
+            "properties": {
+                "feedback": {
+                    "type": "string"
+                },
+                "image_key": {
+                    "type": "string"
+                },
+                "is_helpful": {
+                    "type": "boolean"
+                },
+                "reviewer_email": {
+                    "type": "string"
+                }
+            }
+        },
         "model.MinedImage": {
             "type": "object",
             "properties": {
@@ -460,46 +540,6 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "new_password": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                }
-            }
-        },
-        "model.User": {
-            "type": "object",
-            "required": [
-                "email",
-                "password",
-                "username"
-            ],
-            "properties": {
-                "date_created": {
-                    "type": "string"
-                },
-                "date_updated": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "first_name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "last_name": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "profile_key": {
-                    "type": "string"
-                },
-                "profile_url": {
                     "type": "string"
                 },
                 "username": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1,112 +1,4 @@
 {
-
-  "basePath": "/api/v1",
-  "definitions": {
-    "model.Ping": {
-      "properties": {
-        "email": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
-    "utility.Response": {
-      "properties": {
-        "code": {
-          "type": "integer"
-        },
-        "data": {},
-        "error": {
-          "description": "for errors that occur even if request is successful"
-        },
-        "extra": {},
-        "message": {
-          "type": "string"
-        },
-        "name": {
-          "description": "name of the error",
-          "type": "string"
-        },
-        "status": {
-          "type": "string"
-        }
-      },
-      "type": "object"
-    }
-  },
-  "host": "localhost:9000",
-  "info": {
-    "contact": {},
-    "description": "A picture mining service API in Go using Gin framework.",
-    "title": "Minergram",
-    "version": "1.0"
-  },
-  "paths": {
-    "/api/v1/health": {
-      "get": {
-        "description": "Responds with the server status as JSON.",
-        "produces": ["application/json"],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/utility.Response"
-            }
-          }
-        },
-        "summary": "Checks the status of the server",
-        "tags": ["health"]
-      },
-      "post": {
-        "description": "Send a dummy post request to test the status of the server",
-        "parameters": [
-          {
-            "description": "Ping JSON",
-            "in": "body",
-            "name": "ping",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/model.Ping"
-            }
-          }
-        ],
-        "produces": ["application/json"],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "$ref": "#/definitions/utility.Response"
-            }
-          }
-        },
-        "summary": "Checks the status of the server",
-        "tags": ["health"]
-      }
-    },
-    "/admin/users/{username}": {
-      "delete": {
-        "tags": ["admin"],
-        "summary": "Delete a user",
-        "description": "Delete a user",
-        "operationId": "deleteUser",
-        "parameters": [
-          {
-            "name": "username",
-            "in": "path",
-            "description": "",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "user successfully deleted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
     "schemes": [
         "https"
     ],
@@ -148,34 +40,6 @@
                 }
             }
         },
-        "/admin/users": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "List all users",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "admin"
-                ],
-                "summary": "List all users",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/model.User"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/health": {
             "get": {
                 "description": "Responds with the server status as JSON.",
@@ -194,20 +58,36 @@
                         }
                     }
                 }
-              }
-            }
-          },
-          "500": {
-            "description": "unable to delete user",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
+            },
+            "post": {
+                "description": "Send a dummy post request to test the status of the server",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Checks the status of the server",
+                "parameters": [
+                    {
+                        "description": "Ping JSON",
+                        "name": "ping",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.Ping"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
                 }
-              }
             }
-
-          }
         },
         "/batch-service/process-batch-api": {
             "post": {
@@ -239,6 +119,66 @@
                 "responses": {
                     "200": {
                         "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/feedback": {
+            "post": {
+                "description": "Send feedback to discripto",
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Sends feedback to discripto",
+                "parameters": [
+                    {
+                        "description": "Create feedback",
+                        "name": "Feedback",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.FeedbackRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.FeedbackCreatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/feedback/all": {
+            "get": {
+                "description": "Gets all feedback sent to discripto",
+                "tags": [
+                    "Feedback"
+                ],
+                "summary": "Gets all feedback sent discripto",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/model.Feedback"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
                         "schema": {
                             "$ref": "#/definitions/utility.Response"
                         }
@@ -399,43 +339,8 @@
                         }
                     }
                 }
-          }
-      }
-    },
-    "/admin/mined-images": {
-      "get": {
-        "tags": "admin",
-        "summary": "Get all mined Images",
-        "description": "Get all mined Images",
-        "operationId": "getmineImages",
-        "produces": ["application/json"],
-        "responses": {
-          "200": {
-            "description": "user successfully deleted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-    "definitions": {
-        "model.MineImageResponse": {
-            "type": "object",
-            "properties": {
-                "date_created": {
-                    "type": "string"
-                },
-                "date_modified": {
-                    "type": "string"
-                },
-                "image_name": {
-                    "type": "string"
-                },
-                "image_path": {
-                    "type": "string"
-                },
-                "text_content": {
-                    "type": "string"
+            }
         },
-        
         "/update-user": {
             "patch": {
                 "description": "Updates a User's information - email,firstName,lastName,password - Bearer token required - To change password, current_password, new_password and confirm_password(repeat of the new password) are required",
@@ -497,6 +402,54 @@
         }
     },
     "definitions": {
+        "model.Feedback": {
+            "type": "object",
+            "properties": {
+                "date_created": {
+                    "type": "string"
+                },
+                "feedback": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "image_key": {
+                    "type": "string"
+                },
+                "is_helpful": {
+                    "type": "boolean"
+                },
+                "reviewer_email": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.FeedbackCreatedResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.FeedbackRequest": {
+            "type": "object",
+            "properties": {
+                "feedback": {
+                    "type": "string"
+                },
+                "image_key": {
+                    "type": "string"
+                },
+                "is_helpful": {
+                    "type": "boolean"
+                },
+                "reviewer_email": {
+                    "type": "string"
+                }
+            }
+        },
         "model.MinedImage": {
             "type": "object",
             "properties": {
@@ -562,16 +515,7 @@
                 "email": {
                     "type": "string"
                 }
-              }
             }
-
-          },
-          "500": {
-            "description": "unable to delete user",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
         },
         "model.UpdateUser": {
             "type": "object",
@@ -592,46 +536,6 @@
                     "type": "string"
                 },
                 "new_password": {
-                    "type": "string"
-                },
-                "username": {
-                    "type": "string"
-                }
-            }
-        },
-        "model.User": {
-            "type": "object",
-            "required": [
-                "email",
-                "password",
-                "username"
-            ],
-            "properties": {
-                "date_created": {
-                    "type": "string"
-                },
-                "date_updated": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "first_name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "last_name": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "profile_key": {
-                    "type": "string"
-                },
-                "profile_url": {
                     "type": "string"
                 },
                 "username": {
@@ -732,9 +636,7 @@
                 "status": {
                     "type": "string"
                 }
-              }
             }
-          }
         }
     },
     "securityDefinitions": {
@@ -744,7 +646,4 @@
             "in": "header \"Bearer \u003cadd access token here\u003e\""
         }
     }
-  },
-  "schemes": ["http"],
-  "swagger": "2.0"
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,5 +1,36 @@
-basePath: /api/v1
+basePath: /api/v1/
 definitions:
+  model.Feedback:
+    properties:
+      date_created:
+        type: string
+      feedback:
+        type: string
+      id:
+        type: string
+      image_key:
+        type: string
+      is_helpful:
+        type: boolean
+      reviewer_email:
+        type: string
+    type: object
+  model.FeedbackCreatedResponse:
+    properties:
+      message:
+        type: string
+    type: object
+  model.FeedbackRequest:
+    properties:
+      feedback:
+        type: string
+      image_key:
+        type: string
+      is_helpful:
+        type: boolean
+      reviewer_email:
+        type: string
+    type: object
   model.MinedImage:
     properties:
       dateCreated:
@@ -60,33 +91,6 @@ definitions:
         type: string
       username:
         type: string
-    type: object
-  model.User:
-    properties:
-      date_created:
-        type: string
-      date_updated:
-        type: string
-      email:
-        type: string
-      first_name:
-        type: string
-      id:
-        type: string
-      last_name:
-        type: string
-      password:
-        type: string
-      profile_key:
-        type: string
-      profile_url:
-        type: string
-      username:
-        type: string
-    required:
-    - email
-    - password
-    - username
     type: object
   model.UserLogin:
     properties:
@@ -176,109 +180,37 @@ paths:
       summary: this returns the mined images of all users
       tags:
       - admin
-  /admin/users:
+  /api/v1/health:
     get:
-      description: List all users
+      description: Responds with the server status as JSON.
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/model.User'
-            type: array
-      security:
-      - BearerAuth: []
-      summary: List all users
-      tags:
-      - admin
-  /api/v1/health:
-    get:
-      description: Responds with the server status as JSON.
-      produces:
-        - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: "#/definitions/utility.Response"
+            $ref: '#/definitions/utility.Response'
       summary: Checks the status of the server
       tags:
-        - health
+      - health
     post:
       description: Send a dummy post request to test the status of the server
       parameters:
-        - description: Ping JSON
-          in: body
-          name: ping
-          required: true
-          schema:
-            $ref: "#/definitions/model.Ping"
+      - description: Ping JSON
+        in: body
+        name: ping
+        required: true
+        schema:
+          $ref: '#/definitions/model.Ping'
       produces:
-        - application/json
+      - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: "#/definitions/utility.Response"
+            $ref: '#/definitions/utility.Response'
       summary: Checks the status of the server
       tags:
-        - health
-  /admin/users/{username}:
-    delete:
-      tags:
-        - admin
-      summary: Delete a user
-      description: Delete a user
-      operationId: deleteUser
-      parameters:
-        - name: username
-          in: path
-          description: ""
-          required: true
-          schema:
-            type: string
-      responses:
-        "200":
-          description: user successfully deleted
-          content:
-            application/json:
-              schema:
-                type: object
-
-        "500":
-          description: unable to delete user
-          content:
-            application/json:
-              schema:
-                type: object
-
-  /admin/mined-images:
-    get:
-      tags: -a
-      summary: Get all mined Images
-      description: Get all mined Images
-      operationId: getmineImages
-      produces:
-        - application/json
-      responses:
-        "200":
-          description: user successfully deleted
-          content:
-            application/json:
-              schema:
-                type: object
-        "500":
-          description: unable to delete user
-          content:
-            application/json:
-              schema:
-                type: object
-
-schemes:
-  - http
-
       - health
   /batch-service/process-batch-api:
     post:
@@ -303,6 +235,45 @@ schemes:
       summary: Processes a batch of images
       tags:
       - batch-api
+  /feedback:
+    post:
+      description: Send feedback to discripto
+      parameters:
+      - description: Create feedback
+        in: body
+        name: Feedback
+        required: true
+        schema:
+          $ref: '#/definitions/model.FeedbackRequest'
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.FeedbackCreatedResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utility.Response'
+      summary: Sends feedback to discripto
+      tags:
+      - Feedback
+  /feedback/all:
+    get:
+      description: Gets all feedback sent to discripto
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/model.Feedback'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utility.Response'
+      summary: Gets all feedback sent discripto
+      tags:
+      - Feedback
   /forgot-password:
     post:
       description: Send a dummy post request to test the status of the server

--- a/internal/constants/database.go
+++ b/internal/constants/database.go
@@ -6,4 +6,5 @@ const (
 	BatchCollection      = "batches"
 	BatchImageCollection = "batch_images"
 	SubscriberEmail = "subscribers"
+	FeedbackCollection = "reviews"
 )

--- a/internal/model/feedback.go
+++ b/internal/model/feedback.go
@@ -1,0 +1,19 @@
+package model
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+type Feedback struct{
+	ID     primitive.ObjectID `bson:"_id, omitempty"`
+	ReviewerEmail string `bson:"reviewer_email" json:"reviewer_email"`
+	ImageKey string `bson:"image_id" json:"image_key"`
+	IsHelpful  bool `bson:"is_helpful" json:"is_helpful"`
+	Feedback string `bson:"feedback" json:"feedback"`
+	DateCreated  time.Time `bson:"date_created" json:"date_created"`
+}
+
+type FeedbackCreatedResponse struct {
+	Message string `json:"message"`
+}

--- a/internal/model/feedback.go
+++ b/internal/model/feedback.go
@@ -14,6 +14,12 @@ type Feedback struct{
 	DateCreated  time.Time `bson:"date_created" json:"date_created"`
 }
 
+type FeedbackRequest struct {
+	ReviewerEmail string `bson:"reviewer_email" json:"reviewer_email"`
+	ImageKey string `bson:"image_id" json:"image_key"`
+	IsHelpful  bool `bson:"is_helpful" json:"is_helpful"`
+	Feedback string `bson:"feedback" json:"feedback"`
+}
 type FeedbackCreatedResponse struct {
 	Message string `json:"message"`
 }

--- a/pkg/handler/feedback/feedback.go
+++ b/pkg/handler/feedback/feedback.go
@@ -15,6 +15,14 @@ type Controller struct {
 	Logger   *utility.Logger
 }
 
+// Post             godoc
+// @Summary    Sends feedback to discripto
+// @Description Send feedback to discripto
+// @Tags        Feedback
+// @Param       Feedback body model.FeedbackRequest true "Create feedback" model.Feedback
+// @Success     200  {object} model.FeedbackCreatedResponse
+// @Failure  	400 {object} utility.Response
+// @Router      /feedback [post]
 func (base *Controller) AcceptFeedback(c *gin.Context){
 	var Feedback model.Feedback
 
@@ -34,6 +42,13 @@ func (base *Controller) AcceptFeedback(c *gin.Context){
 	c.JSON(http.StatusCreated, feedback)
 }
 
+// Get             godoc
+// @Summary     Gets all feedback sent discripto
+// @Description Gets all feedback sent to discripto
+// @Tags        Feedback
+// @Success     200  {object} []model.Feedback
+// @Failure  	400 {object} utility.Response
+// @Router      /feedback/all [get]
 func (base *Controller) GetAllFeedback(c *gin.Context){
 	reviews, err := feedback.GetAllFeedback()
 

--- a/pkg/handler/feedback/feedback.go
+++ b/pkg/handler/feedback/feedback.go
@@ -1,0 +1,46 @@
+package feedback
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"github.com/workshopapps/pictureminer.api/internal/model"
+	"github.com/workshopapps/pictureminer.api/service/feedback"
+	"github.com/workshopapps/pictureminer.api/utility"
+)
+
+type Controller struct {
+	Validate *validator.Validate
+	Logger   *utility.Logger
+}
+
+func (base *Controller) AcceptFeedback(c *gin.Context){
+	var Feedback model.Feedback
+
+	err:= c.Bind(&Feedback)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "error", "Unable to bind user signup details", err, nil)
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+	feedback, err := feedback.CollectFeedbackFromUser(Feedback)
+	if err != nil {
+		rd := utility.BuildErrorResponse(400, "error", "could not parse feedback", err, nil)
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+
+	c.JSON(http.StatusCreated, feedback)
+}
+
+func (base *Controller) GetAllFeedback(c *gin.Context){
+	reviews, err := feedback.GetAllFeedback()
+
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusBadRequest, "failed", "could not get all the reviews", nil, gin.H{"error": err.Error()})
+		c.JSON(http.StatusBadRequest, rd)
+		return
+	}
+	c.JSON(http.StatusOK, reviews)
+}

--- a/pkg/router/feedback.go
+++ b/pkg/router/feedback.go
@@ -1,0 +1,21 @@
+package router
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-playground/validator/v10"
+	"github.com/workshopapps/pictureminer.api/pkg/handler/feedback"
+	"github.com/workshopapps/pictureminer.api/utility"
+)
+
+func Feedback(r *gin.Engine, validate *validator.Validate, ApiVersion string, logger *utility.Logger) *gin.Engine {
+
+	feedback:= feedback.Controller{Validate: validate, Logger: logger}
+	feedbackUrl := r.Group(fmt.Sprintf("/api/%v", ApiVersion))
+	{
+		feedbackUrl.POST("/feedback", feedback.AcceptFeedback)
+		feedbackUrl.GET("/feedback/all", feedback.GetAllFeedback)
+	}
+	return r
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -70,6 +70,7 @@ func Setup(validate *validator.Validate, logger *utility.Logger) *gin.Engine {
 	MineService(r, validate, ApiVersion, logger)
 	Admin(r, validate, ApiVersion, logger)
 	SwaggerDocs(r, ApiVersion)
+	Feedback(r, validate, ApiVersion, logger)
 
 	r.NoRoute(func(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{

--- a/service/feedback/feedback.go
+++ b/service/feedback/feedback.go
@@ -1,0 +1,46 @@
+package feedback
+
+import (
+	"context"
+	"time"
+
+	"github.com/workshopapps/pictureminer.api/internal/config"
+	"github.com/workshopapps/pictureminer.api/internal/constants"
+	"github.com/workshopapps/pictureminer.api/internal/model"
+	"github.com/workshopapps/pictureminer.api/pkg/repository/storage/mongodb"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func CollectFeedbackFromUser(feedback model.Feedback) (model.FeedbackCreatedResponse, error){
+	
+	feedback.ID = primitive.NewObjectID()
+	feedback.DateCreated = time.Now()
+
+	//save to the database
+	database := config.GetConfig().Mongodb.Database
+	feedbackCollection := mongodb.GetCollection(mongodb.Connection(), database, constants.FeedbackCollection)
+	_, err := feedbackCollection.InsertOne(context.TODO(), feedback)
+
+	if err != nil {
+		return model.FeedbackCreatedResponse{} , err
+	}
+	feedbck:= model.FeedbackCreatedResponse{
+		
+		Message: "Response was successfully received",
+	}
+	return feedbck, nil
+}
+
+func GetAllFeedback()([]model.Feedback, error){
+	ctx := context.TODO()
+	cursor, err := mongodb.SelectFromCollection(ctx, config.GetConfig().Mongodb.Database, constants.FeedbackCollection, bson.M{})
+
+	if err != nil {
+		return []model.Feedback{}, err
+	}
+
+	var reviews = make([]model.Feedback, 0)
+	cursor.All(ctx, &reviews)
+	return reviews, nil
+}


### PR DESCRIPTION
## [Linear Ticket](https://linear.app/team-discripto/issue/BE-92/implementation-of-the-reviews-icon)

## Task:
create a table/endpoint to collect customer feedback and reviews.

## Details:
When initiated, it gets the neccessary feedback from the user and stores it on the server 

## How to test:
### To collect feedback
If running locally or live, vist the endpoint (http://localhost:9000/api/v1/feedback) and pass the following data to the request body

```json
{
  "feedback": "string",
  "image_key": "string",
  "is_helpful": true,
  "reviewer_email": "string"
}
```
A feedback object would b sent to the server if successful, you should get a response looking something like 

```json 
{
  "message": "Response was successfully received"
}
```
## Preview
<img width="1280" alt="Screenshot 2022-12-08 at 14 39 22" src="https://user-images.githubusercontent.com/86890896/206461150-3e5d874b-f45c-48bc-8cf3-8acd98f02443.png">


P.s when testing live, visit (https://discripto.hng.tech/api1/api/v1/feedback)


### To display all feedback collected
If running locally or live, vist the endpoint (http://localhost:9000/api/v1/feedback/all) and array of all the feedback collected should be returned.

## Preview
<img width="1280" alt="Screenshot 2022-12-08 at 14 40 10" src="https://user-images.githubusercontent.com/86890896/206461230-caae9b4e-2d0a-4545-a081-67b090043a50.png">

P.s when testing live, visit (https://discripto.hng.tech/api1/api/v1/feedback/all)