### PR TITLE
fix/ Fix parse-CSV functions to allow image urls with query parameters

### DIFF
--- a/service/batch-service/batch-api.go
+++ b/service/batch-service/batch-api.go
@@ -1,12 +1,9 @@
 package batchservice
 
 import (
-	"encoding/csv"
 	"encoding/json"
-	"io"
 	"mime/multipart"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/workshopapps/pictureminer.api/internal/constants"
@@ -66,46 +63,6 @@ func ProcessBatchAPI(userID string, req *http.Request) (*model.ProcessBatchAPIRe
 	go processBatch(userEmail, response.Name, response.Description, userID, batchID, response.Tags, jsonReq.Images)
 
 	return response, nil
-}
-
-func parseCSVURLs(csvFile io.ReadCloser) ([]string, error) {
-	csvReader := csv.NewReader(csvFile)
-	csvFields, err := csvReader.ReadAll()
-	if err != nil {
-		return nil, err
-	}
-
-	urls := make([]string, 0)
-
-	urlFieldNumber := -1
-	for index1, val1 := range csvFields {
-		for index2, val2 := range val1 {
-
-			if index1 == 0 {
-				switch strings.ToLower(val2) {
-				case "urls", "images", "url", "image":
-					urlFieldNumber = index2
-					continue
-				}
-			} else {
-				if urlFieldNumber < 0 {
-					return nil, ERRURLFieldNotPresent
-				}
-
-				if index2 == urlFieldNumber {
-					if utility.ValidImageFormat(val2) {
-						urls = append(urls, val2)
-					}
-				}
-
-				if index2 > urlFieldNumber {
-					continue
-				}
-			}
-		}
-	}
-
-	return urls, nil
 }
 
 func saveBatch(uID string, pb *model.ProcessBatchAPIRequest, time time.Time) (interface{}, error) {

--- a/service/batch-service/batch.go
+++ b/service/batch-service/batch.go
@@ -280,6 +280,13 @@ func isValidURL(url string) bool {
 	}
 
 	ext := strings.ToLower(filepath.Ext(url))
+
+	// check if extension contains query parameters
+	idx := strings.LastIndex(ext, "?")
+	if idx != -1 {
+		ext = ext[:idx]
+	}
+
 	return ext == ".png" || ext == ".jpg" || ext == ".jpeg"
 }
 

--- a/service/batch-service/csv-parser.go
+++ b/service/batch-service/csv-parser.go
@@ -23,6 +23,12 @@ func getUrlHeaderIndex(headers []string) (int, error) {
 func checkExtension(url string) bool {
 	mime_types := []string{".png", ".jpg", ".jpeg"}
 
+	// check if extension contains query params
+	idx := strings.LastIndex(url, "?")
+	if idx != -1 {
+		url = url[:idx]
+	}
+
 	for _, mime_type := range mime_types {
 		if strings.HasSuffix(url, mime_type) {
 			return true


### PR DESCRIPTION
### Fix

- This is a fix to the parse CSV functions to allow valid image URL's with query parameters.
- For example, a valid image url such as https://cdn.britannica.com/22/187222-050-07B17FB6/apples-on-a-tree-branch.jpg?w=400&h=300&c=crop would now be parsed as a valid image URL.

### Demo 
The screenshot below shows the result of a call to the download CSV endpoint of a batch process. The batch process accepts one of its URL's as a valid image URL with query parameters, this URL is parsed and tagged as an "apple" as seen below.

![Screenshot from 2022-12-09 02-32-51](https://user-images.githubusercontent.com/63949797/206602990-ad3b3bf7-9de3-4771-8e87-b9f52e846d2a.png)

