### PR TITLE
feat(PM-39): account subscription status countdown

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -345,6 +345,76 @@ const docTemplate = `{
                 }
             }
         },
+        "/subscription": {
+            "get": {
+                "description": "get subscription status information",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Fetch Subscription",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "email",
+                        "description": "email of the user",
+                        "name": "user",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.SubscriberEmail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a user subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Create Subscription",
+                "parameters": [
+                    {
+                        "description": "User Subscription",
+                        "name": "User",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.SubscriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.SubscriberEmail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/update-user": {
             "patch": {
                 "description": "Updates a User's information - email,firstName,lastName,password - Bearer token required - To change password, current_password, new_password and confirm_password(repeat of the new password) are required",
@@ -517,6 +587,49 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.SubscriberEmail": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "_id": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "subscribed": {
+                    "type": "boolean"
+                },
+                "subscription_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.SubscriptionRequest": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "subscription_type": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -341,6 +341,76 @@
                 }
             }
         },
+        "/subscription": {
+            "get": {
+                "description": "get subscription status information",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Fetch Subscription",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "format": "email",
+                        "description": "email of the user",
+                        "name": "user",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.SubscriberEmail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "description": "create a user subscription",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Create Subscription",
+                "parameters": [
+                    {
+                        "description": "User Subscription",
+                        "name": "User",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/model.SubscriptionRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.SubscriberEmail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/utility.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/update-user": {
             "patch": {
                 "description": "Updates a User's information - email,firstName,lastName,password - Bearer token required - To change password, current_password, new_password and confirm_password(repeat of the new password) are required",
@@ -513,6 +583,49 @@
             "type": "object",
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.SubscriberEmail": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "_id": {
+                    "type": "string"
+                },
+                "email": {
+                    "type": "string"
+                },
+                "expires_at": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "subscribed": {
+                    "type": "boolean"
+                },
+                "subscription_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.SubscriptionRequest": {
+            "type": "object",
+            "required": [
+                "email"
+            ],
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "subscription_type": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -75,6 +75,34 @@ definitions:
       email:
         type: string
     type: object
+  model.SubscriberEmail:
+    properties:
+      _id:
+        type: string
+      email:
+        type: string
+      expires_at:
+        type: string
+      price:
+        type: number
+      subscribed:
+        type: boolean
+      subscription_type:
+        type: string
+    required:
+    - email
+    type: object
+  model.SubscriptionRequest:
+    properties:
+      email:
+        type: string
+      price:
+        type: number
+      subscription_type:
+        type: string
+    required:
+    - email
+    type: object
   model.UpdateUser:
     properties:
       confirm_password:
@@ -372,6 +400,52 @@ paths:
           schema:
             $ref: '#/definitions/model.UserResponse'
       summary: Signs Up a User
+      tags:
+      - users
+  /subscription:
+    get:
+      description: get subscription status information
+      parameters:
+      - description: email of the user
+        format: email
+        in: query
+        name: user
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.SubscriberEmail'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utility.Response'
+      summary: Fetch Subscription
+      tags:
+      - users
+    post:
+      description: create a user subscription
+      parameters:
+      - description: User Subscription
+        in: body
+        name: User
+        required: true
+        schema:
+          $ref: '#/definitions/model.SubscriptionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.SubscriberEmail'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/utility.Response'
+      summary: Create Subscription
       tags:
       - users
   /update-user:

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -70,7 +70,7 @@ type SubscriberEmail struct {
 	ID          primitive.ObjectID `bson:"_id" json:"_id"`
 	Email       string             `bson:"email" json:"email" validate:"required,email"`
 	Subscribed  bool              `bson:"subscribed" json:"subscribed"`
-	Price 		float64				`bson:"pricing" json:"pricing"`
+	Price 		float64				`bson:"price" json:"price"`
 	SubscriptionType    string `bson:"subscription_type" json:"subscription_type"`
 	ExpiresAt   time.Time	`bson:"expires_at" json:"expires_at"`
 }

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -70,4 +70,7 @@ type SubscriberEmail struct {
 	ID          primitive.ObjectID `bson:"_id" json:"_id"`
 	Email       string             `bson:"email" json:"email" validate:"required,email"`
 	Subscribed  bool              `bson:"subscribed" json:"subscribed"`
+	Price 		float64				`bson:"pricing" json:"pricing"`
+	SubscriptionType    string `bson:"subscription_type" json:"subscription_type"`
+	ExpiresAt   time.Time	`bson:"expires_at" json:"expires_at"`
 }

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -74,3 +74,9 @@ type SubscriberEmail struct {
 	SubscriptionType    string `bson:"subscription_type" json:"subscription_type"`
 	ExpiresAt   time.Time	`bson:"expires_at" json:"expires_at"`
 }
+
+type SubscriptionRequest struct {
+	Email           string `bson:"email" json:"email" validate:"required"`
+	Price 		float64				`bson:"price" json:"price"`
+	SubscriptionType    string `bson:"subscription_type" json:"subscription_type"`
+}

--- a/pkg/handler/user/subscriber.go
+++ b/pkg/handler/user/subscriber.go
@@ -38,3 +38,24 @@ func (base *Controller) SubscriberEmail(c *gin.Context) {
 	object := utility.BuildSuccessResponse(200, "Email Submission successful", SubscriberEmailResponse)
 	c.JSON(200, object)
 }
+
+func (base *Controller) GetSubscribtion(c *gin.Context) {
+
+	// bind emails to SubscriberEmail struct
+	email, ok:= c.GetQuery("user")
+	if !ok {
+		rd := utility.BuildErrorResponse(400, "error", "please supply the user email", "", nil)
+		c.JSON(400, rd)
+		return
+	}
+
+	sub, err:= user.GetUserSubscribtion(email)
+	if err != nil {
+		rd := utility.BuildErrorResponse(400, "error", "USer may not have subscribtion", err, nil)
+		c.JSON(400, rd)
+		return
+	}
+
+	object := utility.BuildSuccessResponse(200, "Email Submission successful", sub)
+	c.JSON(200, object)
+}

--- a/pkg/handler/user/subscriber.go
+++ b/pkg/handler/user/subscriber.go
@@ -9,7 +9,15 @@ import (
 	"github.com/workshopapps/pictureminer.api/utility"
 )
 
-
+// Create Subscription godoc
+// @Summary      Create Subscription
+// @Description  create a user subscription
+// @Tags         users
+// @Produce      json
+// @Param User body model.SubscriptionRequest true "User Subscription" model.SubscriberEmail
+// @Success      200  {object}   model.SubscriberEmail
+// @Failure      400  {object}  utility.Response
+// @Router       /subscription [post]
 func (base *Controller) SubscriberEmail(c *gin.Context) {
 
 	// bind emails to SubscriberEmail struct
@@ -35,11 +43,21 @@ func (base *Controller) SubscriberEmail(c *gin.Context) {
 		return
 	}
 
-	object := utility.BuildSuccessResponse(200, "Email Submission successful", SubscriberEmailResponse)
+	object := utility.BuildSuccessResponse(200, "Email Subcription successful", SubscriberEmailResponse)
 	c.JSON(200, object)
 }
 
-func (base *Controller) GetSubscribtion(c *gin.Context) {
+
+// Fetch Subscription godoc
+// @Summary      Fetch Subscription
+// @Description  get subscription status information
+// @Tags         users
+// @Produce      json
+// @Param        user    query     string  false  "email of the user"  Format(email)
+// @Success      200  {object}   model.SubscriberEmail
+// @Failure      400  {object}  utility.Response
+// @Router       /subscription [get]
+func (base *Controller) GetSubscription(c *gin.Context) {
 
 	// bind emails to SubscriberEmail struct
 	email, ok:= c.GetQuery("user")
@@ -49,13 +67,13 @@ func (base *Controller) GetSubscribtion(c *gin.Context) {
 		return
 	}
 
-	sub, err:= user.GetUserSubscribtion(email)
+	sub, err:= user.GetUserSubscription(email)
 	if err != nil {
-		rd := utility.BuildErrorResponse(400, "error", "USer may not have subscribtion", err, nil)
+		rd := utility.BuildErrorResponse(400, "error", "USer may not have subscription", err, nil)
 		c.JSON(400, rd)
 		return
 	}
 
-	object := utility.BuildSuccessResponse(200, "Email Submission successful", sub)
+	object := utility.BuildSuccessResponse(200, "User subscription retrieved sucessfully", sub)
 	c.JSON(200, object)
 }

--- a/pkg/router/user.go
+++ b/pkg/router/user.go
@@ -23,7 +23,7 @@ func Auth(r *gin.Engine, validate *validator.Validate, ApiVersion string, logger
 		authUrl.PATCH("/update_user_picture", auth.UpdateProfilePicture)
 		authUrl.PATCH("/update-user", auth.UpdateUser)
 		authUrl.POST("/subscriber-email", auth.SubscriberEmail)
-		authUrl.GET("/subscribtion", auth.GetSubscribtion)
+		authUrl.GET("/subscription", auth.GetSubscription)
 	}
 	return r
 }

--- a/pkg/router/user.go
+++ b/pkg/router/user.go
@@ -23,6 +23,7 @@ func Auth(r *gin.Engine, validate *validator.Validate, ApiVersion string, logger
 		authUrl.PATCH("/update_user_picture", auth.UpdateProfilePicture)
 		authUrl.PATCH("/update-user", auth.UpdateUser)
 		authUrl.POST("/subscriber-email", auth.SubscriberEmail)
+		authUrl.GET("/subscribtion", auth.GetSubscribtion)
 	}
 	return r
 }

--- a/service/user/subscribers.go
+++ b/service/user/subscribers.go
@@ -2,20 +2,32 @@ package user
 
 import (
 	"context"
+	"time"
+
 	"github.com/workshopapps/pictureminer.api/internal/config"
 	"github.com/workshopapps/pictureminer.api/internal/constants"
 	"github.com/workshopapps/pictureminer.api/internal/model"
 	"github.com/workshopapps/pictureminer.api/pkg/repository/storage/mongodb"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func SubscriberEmailResponse(subscriberEmail model.SubscriberEmail) (model.SubscriberEmail, string, int, error) {
-
-
+	//create subscribtion time
+	now:= time.Now()
+	oneMonthLater:= now.AddDate(0,1,1)
+	oneYearLater:= now.AddDate(1,0,0)
+	
+	if subscriberEmail.SubscriptionType == "MONTHLY" || subscriberEmail.SubscriptionType == "monthly"{
+		subscriberEmail.ExpiresAt = oneMonthLater
+	} else {
+		subscriberEmail.ExpiresAt = oneYearLater
+	}
 	subscriberEmail.ID = primitive.NewObjectID()
 	subscriberEmail.Email = subscriberEmail.Email
 	subscriberEmail.Subscribed = true
-
+	
 	// save to DB
 	database := config.GetConfig().Mongodb.Database
 	subscriberCollection := mongodb.GetCollection(mongodb.Connection(), database, constants.SubscriberEmail)
@@ -30,7 +42,27 @@ func SubscriberEmailResponse(subscriberEmail model.SubscriberEmail) (model.Subsc
 		ID:     subscriberEmail.ID,
 		Email:        subscriberEmail.Email,
 		Subscribed:    true,
+		ExpiresAt: subscriberEmail.ExpiresAt,
+		SubscriptionType: subscriberEmail.SubscriptionType,
 	}
 
 	return subscriberResponse, "", 0, nil
+}
+
+func GetUserSubscribtion(email string)(model.SubscriberEmail, error){
+
+	var subcribtion model.SubscriberEmail 
+	//fetch from database
+	database := config.GetConfig().Mongodb.Database
+	ctx := context.TODO()
+	subscriberCollection := mongodb.GetCollection(mongodb.Connection(), database, constants.SubscriberEmail)
+	err :=subscriberCollection.FindOne(ctx, bson.M{"email": email}).Decode(&subcribtion)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			// This error means your query did not match any documents.
+			return model.SubscriberEmail{}, err
+		}
+		return model.SubscriberEmail{}, err
+	}
+	return subcribtion, nil
 }

--- a/service/user/subscribers.go
+++ b/service/user/subscribers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func SubscriberEmailResponse(subscriberEmail model.SubscriberEmail) (model.SubscriberEmail, string, int, error) {
-	//create subscribtion time
+	//create subscription time
 	now:= time.Now()
 	oneMonthLater:= now.AddDate(0,1,1)
 	oneYearLater:= now.AddDate(1,0,0)
@@ -49,7 +49,7 @@ func SubscriberEmailResponse(subscriberEmail model.SubscriberEmail) (model.Subsc
 	return subscriberResponse, "", 0, nil
 }
 
-func GetUserSubscribtion(email string)(model.SubscriberEmail, error){
+func GetUserSubscription(email string)(model.SubscriberEmail, error){
 
 	var subcribtion model.SubscriberEmail 
 	//fetch from database


### PR DESCRIPTION
## [Linear Issue](https://linear.app/team-discripto/issue/PM-39/account-status-countdown)

## Task:
Account status countdown

## Details:
As a user, i should be able to visualize the countdown to my subscription expirations.

## How to test:
### To collect feedback
If running locally or live, vist the endpoint (http://localhost:9000/api/v1/subscription?user=ligma1@gmail.com)  
where ligma1@gmail.com is the email of the user whose subscription you want to receive

A feedback object would b sent to the server if successful, you should get a response looking something like 

```json 
{
    "status": "success",
    "code": 200,
    "message": "Email Subscription successful",
    "data": {
        "_id": "63935eb6e6006ebc182481fb",
        "email": "ligma1@gmail.com",
        "subscribed": true,
        "price": 0,
        "subscription_type": "MONTHLY",
        "expires_at": "2023-01-10T16:13:42.681Z"
    }
}
```

P.s when testing live, visit (https://discripto.hng.tech/api1/api/v1/subscription?user=ligma1@gmail.com)


You can also visit https://discripto.hng.tech/api/v1/docs/index.html#/users/get_subscription to view the swagger test docs