### PR TITLE
Feat/get batches details

### DIFF
--- a/internal/model/batch.go
+++ b/internal/model/batch.go
@@ -47,3 +47,9 @@ type ProcessBatchAPIResponse struct {
 	Status      string    `json:"status"`
 	DateCreated time.Time `bson:"date_created"`
 }
+
+type BatchDetailsResponse struct {
+	Total    int `json:"total"`
+	Tagged   int `json:"tagged"`
+	Untagged int `json:"untagged"`
+}

--- a/internal/model/batch.go
+++ b/internal/model/batch.go
@@ -48,7 +48,7 @@ type ProcessBatchAPIResponse struct {
 	DateCreated time.Time `bson:"date_created"`
 }
 
-type BatchDetailsResponse struct {
+type BatchesCountResponse struct {
 	Total    int `json:"total"`
 	Tagged   int `json:"tagged"`
 	Untagged int `json:"untagged"`

--- a/pkg/handler/batch-service/process-batch.go
+++ b/pkg/handler/batch-service/process-batch.go
@@ -286,6 +286,28 @@ func (base *Controller) DownloadCsv(c *gin.Context) {
 
 }
 
+func (base *Controller) CountBatches(c *gin.Context) {
+	secretKey := config.GetConfig().Server.Secret
+	token := utility.ExtractToken(c)
+	userId, err := utility.GetKey("id", token, secretKey)
+	if err != nil {
+		rd := utility.BuildErrorResponse(http.StatusUnauthorized, "failed", "could not verify token", gin.H{"error": err.Error()}, nil)
+		c.JSON(http.StatusUnauthorized, rd)
+		return
+	}
+
+	userID, ok := userId.(string)
+	if !ok {
+		rd := utility.BuildErrorResponse(http.StatusUnauthorized, "failed", "could not verify token", gin.H{"error": "invalid token type"}, nil)
+		c.JSON(http.StatusUnauthorized, rd)
+		return
+	}
+
+	resp, err := batchservice.CountBatchesService(userID)
+
+	rd := utility.BuildSuccessResponse(http.StatusOK, "get batches count success", resp)
+	c.JSON(http.StatusOK, rd)
+}
 
 func (base *Controller) CountProcess(c *gin.Context) {
 

--- a/pkg/handler/batch-service/process-batch.go
+++ b/pkg/handler/batch-service/process-batch.go
@@ -303,7 +303,12 @@ func (base *Controller) CountBatches(c *gin.Context) {
 		return
 	}
 
-	resp, err := batchservice.CountBatchesService(userID)
+	resp, code, err := batchservice.CountBatchesService(userID)
+	if err != nil {
+		rd := utility.BuildErrorResponse(code, "failed", "could not retrieve batches counts", gin.H{"error": err.Error()}, nil)
+		c.JSON(code, rd)
+		return
+	}
 
 	rd := utility.BuildSuccessResponse(http.StatusOK, "get batches count success", resp)
 	c.JSON(http.StatusOK, rd)

--- a/pkg/router/batch.go
+++ b/pkg/router/batch.go
@@ -22,6 +22,7 @@ func ProcessBatch(r *gin.Engine, validate *validator.Validate, ApiVersion string
 		authUrl.GET("/batch-service/download/:batchid", batch.DownloadCsv)
 		authUrl.DELETE("/batch-service/delete/:id", batch.DeleteBatch)
 		authUrl.GET("/batch-service/count-process", batch.CountProcess)
+		authUrl.GET("/batch-service/batches-counts", batch.CountBatches)
 	}
 
 	return r

--- a/pkg/router/batch.go
+++ b/pkg/router/batch.go
@@ -22,7 +22,7 @@ func ProcessBatch(r *gin.Engine, validate *validator.Validate, ApiVersion string
 		authUrl.GET("/batch-service/download/:batchid", batch.DownloadCsv)
 		authUrl.DELETE("/batch-service/delete/:id", batch.DeleteBatch)
 		authUrl.GET("/batch-service/count-process", batch.CountProcess)
-		authUrl.GET("/batch-service/batches-counts", batch.CountBatches)
+		authUrl.GET("/batch-service/count-batches", batch.CountBatches)
 	}
 
 	return r

--- a/service/batch-service/get-batch.go
+++ b/service/batch-service/get-batch.go
@@ -2,6 +2,8 @@ package batchservice
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"github.com/workshopapps/pictureminer.api/internal/config"
 	"github.com/workshopapps/pictureminer.api/internal/constants"
@@ -92,6 +94,27 @@ func GetImagesInBatch(batchId string) ([]model.BatchImage, error) {
 	return batchImages, nil
 }
 
-func CountBatchesService(userId string) (interface{}, int, error) {
+func CountBatchesService(userID string) (interface{}, int, error) {
+	db := config.GetConfig().Mongodb.Database
+	ctx := context.Background()
+	filter := bson.M{"user_id": userID}
+
+	// get cursor for all batches
+	bcursor, err := mongodb.SelectFromCollection(ctx, db, constants.BatchCollection, filter)
+	if err != nil {
+		return nil, http.StatusInternalServerError, err
+	}
+	defer bcursor.Close(ctx)
+
+	for bcursor.Next(ctx) {
+		var b model.Batch
+		err := bcursor.Decode(&b)
+		if err != nil {
+			fmt.Println(err)
+		} else {
+			fmt.Println(b)
+		}
+	}
+
 	return nil, 0, nil
 }

--- a/service/batch-service/get-batch.go
+++ b/service/batch-service/get-batch.go
@@ -92,6 +92,6 @@ func GetImagesInBatch(batchId string) ([]model.BatchImage, error) {
 	return batchImages, nil
 }
 
-func CountBatchesService(userId string) (interface{}, error) {
-	return nil, nil
+func CountBatchesService(userId string) (interface{}, int, error) {
+	return nil, 0, nil
 }

--- a/service/batch-service/get-batch.go
+++ b/service/batch-service/get-batch.go
@@ -91,3 +91,7 @@ func GetImagesInBatch(batchId string) ([]model.BatchImage, error) {
 
 	return batchImages, nil
 }
+
+func CountBatchesService(userId string) (interface{}, error) {
+	return nil, nil
+}


### PR DESCRIPTION
### Task
Write endpoint to retrieve the count of untagged and tagged images in all the batches a user has processed.

### Detail
- validate auth token
- get all users batches
- get all images in bits of 1,000,000
- for each 1million bit, count tagged/untagged
- build and return success response.

### Preview
![newest](https://user-images.githubusercontent.com/102928664/206753968-2e5b8ce7-db26-4ae0-9bf9-ecc3af4563b8.PNG)
