### PR TITLE
added count down and total mined monthly

### DIFF
--- a/internal/model/mined_image.go
+++ b/internal/model/mined_image.go
@@ -44,7 +44,9 @@ type MineImagePromptResponse struct {
 }
 
 type ProcessCallCount struct {
-	ImageCount    int64    `bson:"image_count" json:"image_count"`
-	BatchCount    int64    `bson:"batch_count" json:"batch_count"`
-	Status			bool	`bson:"status" json:"status"`
+	MinedThisMonth    	int     `bson:"mined_this_month" json:"mined_this_month"`
+	RemainingTomine   	int     `bson:"remaining_to_mine" json:"remaining_to_mine"`
+	ImageCount    		int64   `bson:"image_count" json:"image_count"`
+	BatchCount    		int64   `bson:"batch_count" json:"batch_count"`
+	Status				bool	`bson:"status" json:"status"`
 }

--- a/service/mine-service/mine-service.go
+++ b/service/mine-service/mine-service.go
@@ -176,7 +176,34 @@ func ProcessCount(userId string) (model.ProcessCallCount, error) {
 		status = false
 	}
 
+	plan, err := mongodb.GetUserPlan(userId)
+if err != nil {
+	return response, err
+}
+
+_, time_collection , _ , err := mongodb.GetMinedTime(userId)
+if err != nil {
+	return response, err
+}
+
+
+_, time_batch_collection , _ , err := mongodb.GetBatchTime(userId)
+if err != nil {
+	return response, err
+}
+
+
+totalMined := len(time_collection) + len(time_batch_collection)
+var remaining int
+if plan == "free" || plan == "" {
+    remaining = 10 - totalMined
+  }else{
+    remaining = 100 - totalMined
+  }
+
 	response = model.ProcessCallCount{
+		MinedThisMonth: totalMined,
+		RemainingTomine: remaining,
 		ImageCount:    imageCount,
 		BatchCount:     batchCount,
 		Status:    status,


### PR DESCRIPTION
I added the endpoint
https://discripto.hng.tech/api1/api/v1/batch-service/count-process

Total images mined in the month and total mine requests remaining

the endpoint initially contained total mined for both batch requests and images requests